### PR TITLE
Remove branch suffix to avoid creating multiple PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Fix creating multiple Pull Requests.
 
 ## [0.1.0] - 2023-06-15
 

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,6 @@ runs:
 
         # Branch
         branch: tool-versions-updates
-        branch-suffix: random
 
         # Commit
         commit-message: Update .tool-versions


### PR DESCRIPTION
Closes #4

## Summary

Update the use of `peter-evans/create-pull-request` to not include a random suffix in the branch name for the Pull Request updating the `.tool-versions` file. The effect is that every time this action runs the same branch name is used and so no new Pull Request is created. As a side effect, this also means an open Pull Request may be updated by subsequent runs of this action (if more updates become available). For closed Pull Requests (with or without branch removed) the result is that a new Pull Request will be created (based on manual testing).