### PR TITLE
Install asdf without installing tool plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Don't unnecessarily install tools.
 
 ## [0.1.1] - 2023-06-17
 

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Install asdf
-      uses: asdf-vm/actions/install@v2
+      uses: asdf-vm/actions/setup@v2
     - name: Look for updates
       shell: bash
       run: $GITHUB_ACTION_PATH/bin/update.sh


### PR DESCRIPTION
## Summary

Update the action flow to use [`asdf-vm/actions/setup`](https://github.com/asdf-vm/actions/tree/8b8467c5522bb0aea4977082037e4f2956d67e52/setup) instead of [`asdf-vm/actions/install`](https://github.com/asdf-vm/actions/tree/8b8467c5522bb0aea4977082037e4f2956d67e52/install). The difference is that `/install` installs the asdf CLI *and* tools in `.tool-versions` whereas `/setup` *only* installs the asdf CLI. Not setting up the tools unnecessarily improves the speed (and potentially reliability) of this action.