### PR TITLE
Add commit workflow action

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Update tooling
-        uses: ./
+        uses: ./pr
         with:
           max: 2

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /*
 # except ...
 
+!/.version
+
 ## Build tooling
 !/Dockerfile
 !/Makefile
@@ -26,8 +28,14 @@
 !/.gitignore
 
 ## GitHub Actions
-!/.version
-!/action.yml
+!/commit/
+/commit/**
+!/commit/action.yml
+!/commit/README.md
+!/pr/
+/pr/**
+!/pr/action.yml
+!/pr/README.md
 
 ## GitHub platform
 !/.github/
@@ -39,5 +47,5 @@
 
 ## Source
 !/bin/
-bin/**
+/bin/**
 !/bin/*.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- BREAKING: action moved to `ericcornelissen/tool-versions-update-action/pr`.
+- Added new action `ericcornelissen/tool-versions-update-action/commit`.
 
 ## [0.1.1] - 2023-06-17
 

--- a/README.md
+++ b/README.md
@@ -1,82 +1,24 @@
 # Tool Versions Update Action
 
-A [GitHub Action] to automatically update the tools in your `.tool-versions`
-file.
+A collection of [GitHub Actions] to automatically update the tools in your
+`.tool-versions` file.
 
-This action uses [asdf] and various other GitHub Actions to try and update any
-tools defined in your project's `.tool-versions` and open a Pull Request to
-apply those updates to the project.
+The actions use [asdf] and various other GitHub Actions to try and update any
+tools defined in your project's `.tool-versions` and apply those updates to the
+project.
 
 ## Early Development Notice
 
-This action is currently in early development and so you should expect breaking
+This project is currently in early development and so you should expect breaking
 changes from one version to the next. When using this action it is advised to
 pin to an exact version or commit SHA.
 
 The first stable release (if reached) will be v1.0.0.
 
-## Usage
+## Actions
 
-```yml
-- uses: ericcornelissen/tool-versions-update-action@v0.1.1
-  with:
-    # The $GITHUB_TOKEN or a repository scoped Personal Access Token (PAT).
-    # Default: $GITHUB_TOKEN
-    token: ${{ github.token }}
-
-    # The maximum number of tools to update. 0 indicates no maximum.
-    # Default: 0
-    max: 0
-```
-
-### Full Example
-
-This example is for a workflow that can be triggered manually to create a Pull
-Request to update at most 2 tools defined in `.tool-versions` at the time.
-
-```yml
-name: Tooling
-on:
-  workflow_dispatch: ~
-
-permissions: read-all
-
-jobs:
-  tooling:
-    name: Update tooling
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Update tooling
-        uses: ericcornelissen/tool-versions-update-action@v0.1.1
-        with:
-          max: 2
-```
-
-## Security
-
-### Permissions
-
-This action requires the following permissions:
-
-```yml
-permissions:
-  contents: write # To push a commit
-  pull-requests: write # To open a Pull Request
-```
-
-### Network
-
-This action requires network access to:
-
-```txt
-github.com:443
-objects.githubusercontent.com:443
-```
-
-in addition to any endpoints your asdf plugins use.
+- [`tool-versions-update-action/commit`](./commit/README.md)
+- [`tool-versions-update-action/pr`](./pr/README.md)
 
 ## License
 
@@ -85,5 +27,5 @@ license text. The contents of documentation is licensed under [CC BY 4.0].
 
 [asdf]: https://asdf-vm.com/
 [cc by 4.0]: https://creativecommons.org/licenses/by/4.0/
-[github action]: https://github.com/features/actions
+[github actions]: https://github.com/features/actions
 [license]: ./LICENSE

--- a/commit/README.md
+++ b/commit/README.md
@@ -1,0 +1,80 @@
+# Tool Versions Update Action - Commit
+
+A [GitHub Action] to automatically update the tools in your `.tool-versions`
+file through a commit.
+
+## Usage
+
+```yml
+- uses: ericcornelissen/tool-versions-update-action/commit@v0.1.1
+  with:
+    # The branch to commit to.
+    #
+    # Default: _current or default branch_
+    branch: develop
+
+    # The maximum number of tools to update. 0 indicates no maximum.
+    #
+    # Default: 0
+    max: 0
+
+    # The $GITHUB_TOKEN or a repository scoped Personal Access Token (PAT).
+    #
+    # Default: $GITHUB_TOKEN
+    token: ${{ github.token }}
+```
+
+### Full Example
+
+This example is for a workflow that can be triggered manually to create a commit
+to update at most 2 tools defined in `.tool-versions` at the time.
+
+```yml
+name: Tooling
+on:
+  workflow_dispatch: ~
+
+permissions: read-all
+
+jobs:
+  tooling:
+    name: Update tooling
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Update tooling
+        uses: ericcornelissen/tool-versions-update-action/commit@v0.1.1
+        with:
+          max: 2
+```
+
+## Security
+
+### Permissions
+
+This action requires the following permissions:
+
+```yml
+permissions:
+  contents: write # To push a commit
+```
+
+### Network
+
+This action requires network access to:
+
+```txt
+github.com:443
+objects.githubusercontent.com:443
+```
+
+in addition to any endpoints your [asdf] plugins use.
+
+---
+
+The contents of this document are licensed under [CC BY 4.0].
+
+[asdf]: https://asdf-vm.com/
+[cc by 4.0]: https://creativecommons.org/licenses/by/4.0/
+[github action]: https://github.com/features/actions

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -1,0 +1,48 @@
+name: Tool Versions Update Action - commit
+description: Update tools in your .tool-versions file through a commit
+branding:
+  icon: arrow-up-circle
+  color: blue
+
+inputs:
+  branch:
+    description: |
+      The branch to commit to.
+    required: false
+    default: ${{ github.head_ref }}
+  max:
+    description: |
+      The maximum number of tools to update. 0 indicates no maximum.
+    required: false
+    default: 0
+  token:
+    description: |
+      The $GITHUB_TOKEN or a repository scoped Personal Access Token (PAT).
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.head_ref }}
+        token: ${{ inputs.token }}
+    - name: Install asdf
+      uses: asdf-vm/actions/install@v2
+    - name: Look for updates
+      shell: bash
+      run: $GITHUB_ACTION_PATH/../bin/update.sh
+      env:
+        MAX: ${{ inputs.max }}
+    - name: Create commit
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        skip_dirty_check: false
+
+        # Branch
+        branch: ${{ inputs.branch }}
+
+        # Commit
+        commit_message: Update `.tool-versions`

--- a/pr/README.md
+++ b/pr/README.md
@@ -1,0 +1,77 @@
+# Tool Versions Update Action - Pull Request
+
+A [GitHub Action] to automatically update the tools in your `.tool-versions`
+file through a Pull Request.
+
+## Usage
+
+```yml
+- uses: ericcornelissen/tool-versions-update-action/pr@v0.1.1
+  with:
+    # The maximum number of tools to update. 0 indicates no maximum.
+    #
+    # Default: 0
+    max: 0
+
+    # The $GITHUB_TOKEN or a repository scoped Personal Access Token (PAT).
+    #
+    # Default: $GITHUB_TOKEN
+    token: ${{ github.token }}
+```
+
+### Full Example
+
+This example is for a workflow that can be triggered manually to create a Pull
+Request to update at most 2 tools defined in `.tool-versions` at the time.
+
+```yml
+name: Tooling
+on:
+  workflow_dispatch: ~
+
+permissions: read-all
+
+jobs:
+  tooling:
+    name: Update tooling
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Update tooling
+        uses: ericcornelissen/tool-versions-update-action/pr@v0.1.1
+        with:
+          max: 2
+```
+
+## Security
+
+### Permissions
+
+This action requires the following permissions:
+
+```yml
+permissions:
+  contents: write # To push a commit
+  pull-requests: write # To open a Pull Request
+```
+
+### Network
+
+This action requires network access to:
+
+```txt
+github.com:443
+objects.githubusercontent.com:443
+```
+
+in addition to any endpoints your [asdf] plugins use.
+
+---
+
+The contents of this document are licensed under [CC BY 4.0].
+
+[asdf]: https://asdf-vm.com/
+[cc by 4.0]: https://creativecommons.org/licenses/by/4.0/
+[github action]: https://github.com/features/actions

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -1,20 +1,20 @@
-name: Tool Versions Update Action
-description: Update tools in your .tool-versions file
+name: Tool Versions Update Action - Pull Request
+description: Update tools in your .tool-versions file through a Pull Request
 branding:
   icon: arrow-up-circle
   color: blue
 
 inputs:
-  token:
-    description: |
-      The $GITHUB_TOKEN or a repository scoped Personal Access Token (PAT).
-    required: false
-    default: ${{ github.token }}
   max:
     description: |
       The maximum number of tools to update. 0 indicates no maximum.
     required: false
     default: 0
+  token:
+    description: |
+      The $GITHUB_TOKEN or a repository scoped Personal Access Token (PAT).
+    required: false
+    default: ${{ github.token }}
 
 runs:
   using: composite
@@ -25,7 +25,7 @@ runs:
       uses: asdf-vm/actions/install@v2
     - name: Look for updates
       shell: bash
-      run: $GITHUB_ACTION_PATH/bin/update.sh
+      run: $GITHUB_ACTION_PATH/../bin/update.sh
       env:
         MAX: ${{ inputs.max }}
     - name: Create Pull Request


### PR DESCRIPTION
Closes #2

## Summary

Re-organize the repository to better support multiple actions for different workflows, moving the action originally at the root into the `/pr/action.yml`. The documentation for this action moved with it to `/pr/README.md` - the documentation at the root is now more bare bones with links to the available actions.

This re-organization supports adding a new version of the action, one that creates a commit instead of a Pull Request. This new action can be found in `/commit`. It's very similar to the Pull Request action from the user perspective, just with an additional option that allows user to choose the branch to commit to.