### PR TITLE
Group logs for updating tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Add log grouping.
 
 ## [0.1.1] - 2023-06-17
 

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -12,6 +12,14 @@ debug() {
 	echo "::debug::$1"
 }
 
+group_start() {
+	echo "::group::$1"
+}
+
+group_end() {
+	echo "::endgroup::"
+}
+
 ################################################################################
 ### Main #######################################################################
 ################################################################################
@@ -19,6 +27,7 @@ debug() {
 max_capacity=${MAX}
 remaining_capacity=${MAX}
 
+group_start "Updating tools"
 debug "starting update capacity: ${remaining_capacity}"
 
 while read -r line; do
@@ -58,3 +67,5 @@ while read -r line; do
 		;;
 	esac
 done <".tool-versions"
+
+group_end


### PR DESCRIPTION
Relates to #10

## Summary

Improve the overall logging of this action by grouping the logs produced by the logic within the action. This improves readability of the overall logs by creating clearer separation.

This is supported by two new helpers to start and end a group. Their implementation is based on the corresponding [`@actions/core` implementation](https://github.com/actions/toolkit/blob/a6bf872/packages/core/src/core.ts#L301-L317)