### PR TITLE
Add continuous Gitleaks scan

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,47 @@
+name: Audit
+on:
+  pull_request: ~
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: 0 1 * * *
+
+permissions: read-all
+
+jobs:
+  secrets:
+    name: Secrets
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          fetch-depth: 0
+      - name: Scan for secrets
+        uses: gitleaks/gitleaks-action@1f2d10fb689bc07a5f56f48d6db61f5bbbe772fa # v2.3.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: false
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
+          GITLEAKS_ENABLE_SUMMARY: false
+  semgrep:
+    name: Semgrep
+    runs-on: ubuntu-22.04
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    permissions:
+      security-events: write # To upload SARIF results
+    container:
+      image: returntocorp/semgrep
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Perform Semgrep analysis
+        run: semgrep ci --sarif --output semgrep.sarif
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+      - name: Upload Semgrep report to GitHub
+        uses: github/codeql-action/upload-sarif@6c089f53dd51dc3fc7e599c3cb5356453a52ca9e # v2.20.0
+        if: ${{ failure() || success() }}
+        with:
+          sarif_file: semgrep.sarif

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,26 +30,6 @@ jobs:
         run: make lint-docker
       - name: Build
         run: make dev-img
-  semgrep:
-    name: Semgrep
-    runs-on: ubuntu-22.04
-    if: ${{ github.actor != 'dependabot[bot]' }}
-    permissions:
-      security-events: write # To upload SARIF results
-    container:
-      image: returntocorp/semgrep
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - name: Perform Semgrep analysis
-        run: semgrep ci --sarif --output semgrep.sarif
-        env:
-          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
-      - name: Upload Semgrep report to GitHub
-        uses: github/codeql-action/upload-sarif@6c089f53dd51dc3fc7e599c3cb5356453a52ca9e # v2.20.0
-        if: ${{ failure() || success() }}
-        with:
-          sarif_file: semgrep.sarif
   shell:
     name: Shell scripts
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Relates to #14

## Summary

Add a new continuous integration job to run a [Gitleaks](https://gitleaks.io/) scan on commits (to main), Pull Requests, and on a nightly schedule. To be able to run it nightly as well as on PRs and commits a new workflow was created.

In addition, the continuous Semgrep integration was moved from the check workflow into this workflow as it's a similar kind of check that could benefit from being run nightly as well.