### PR TITLE
Add labels option to the Pull Request version of the action

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,4 +19,5 @@ jobs:
       - name: Update tooling
         uses: ./pr
         with:
+          labels: dependencies
           max: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Add labels option to `tool-versions-update-action/pr`.
 
 ## [0.2.0] - 2023-06-18
 

--- a/pr/README.md
+++ b/pr/README.md
@@ -11,7 +11,12 @@ file through a Pull Request.
     # The maximum number of tools to update. 0 indicates no maximum.
     #
     # Default: 0
-    max: 0
+    max: 2
+
+    # A comma or newline-separated list of labels.
+    #
+    # Default: *no labels*
+    labels: tools
 
     # The $GITHUB_TOKEN or a repository scoped Personal Access Token (PAT).
     #

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -10,6 +10,11 @@ inputs:
       The maximum number of tools to update. 0 indicates no maximum.
     required: false
     default: 0
+  labels:
+    description: |
+      A comma or newline-separated list of labels.
+    required: false
+    default: ""
   token:
     description: |
       The $GITHUB_TOKEN or a repository scoped Personal Access Token (PAT).
@@ -36,6 +41,7 @@ runs:
         # Pull Request
         title: Update `.tool-versions`
         body: Bump tools in `.tool-versions`
+        labels: ${{ inputs.labels }}
 
         # Branch
         branch: tool-versions-updates


### PR DESCRIPTION
Closes #3

## Summary

Update the `tool-versions-update-action/pr` Action to accept as input the option "labels" and pass that value on to the Action [`peter-evans/create-pull-request`](https://github.com/peter-evans/create-pull-request) in order to be able to add labels to Pull Requests upon creation.