### PR TITLE
Split audit workflow

### DIFF
--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -1,0 +1,27 @@
+name: Secrets
+on:
+  pull_request: ~
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: 0 1 * * *
+
+permissions: read-all
+
+jobs:
+  secrets:
+    name: Secrets
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          fetch-depth: 0
+      - name: Scan for secrets
+        uses: gitleaks/gitleaks-action@1f2d10fb689bc07a5f56f48d6db61f5bbbe772fa # v2.3.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: false
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
+          GITLEAKS_ENABLE_SUMMARY: false

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,6 +1,5 @@
-name: Audit
+name: Semgrep
 on:
-  pull_request: ~
   push:
     branches:
       - main
@@ -10,25 +9,9 @@ on:
 permissions: read-all
 
 jobs:
-  secrets:
-    name: Secrets
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-        with:
-          fetch-depth: 0
-      - name: Scan for secrets
-        uses: gitleaks/gitleaks-action@1f2d10fb689bc07a5f56f48d6db61f5bbbe772fa # v2.3.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_ENABLE_COMMENTS: false
-          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
-          GITLEAKS_ENABLE_SUMMARY: false
   semgrep:
     name: Semgrep
     runs-on: ubuntu-22.04
-    if: ${{ github.actor != 'dependabot[bot]' }}
     permissions:
       security-events: write # To upload SARIF results
     container:


### PR DESCRIPTION
Relates to #14, #21

## Summary

Split the audit workflow into two separate workflows, one for secret scanning and one for Semgrep. The primary motivator for this is the use of a secret in the Semgrep job, which is not available in Pull Requests from forks (and Dependabot, but this was already considered). As a Result, the Semgrep workflow/job now only runs on the `main` branch as well as on a schedule. The secrets job is unchanged other than that the workflow it is a part of is now named "Secrets".