### PR TITLE
Create bare version of the action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 !/.gitignore
 
 ## GitHub Actions
+!action.yml
 !/commit/
 /commit/**
 !/commit/action.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning].
 
 ## [Unreleased]
 
+- Add action that just updates tools at `tool-versions-update-action`.
 - Add labels option to `tool-versions-update-action/pr`.
 
 ## [0.2.0] - 2023-06-18

--- a/README.md
+++ b/README.md
@@ -15,10 +15,61 @@ pin to an exact version or commit SHA.
 
 The first stable release (if reached) will be v1.0.0.
 
-## Actions
+## Usage
+
+```yml
+- uses: ericcornelissen/tool-versions-update-action@v0.2.0
+  with:
+    # The maximum number of tools to update. 0 indicates no maximum.
+    #
+    # Default: 0
+    max: 1
+```
+
+### Batteries Included
+
+While the base action allows for more freedom, you can use one of this project's
+sub-actions to get up-and-running quickly with one-step automated tooling jobs.
 
 - [`tool-versions-update-action/commit`](./commit/README.md)
 - [`tool-versions-update-action/pr`](./pr/README.md)
+
+### Full Example
+
+This example is for a workflow that can be triggered manually to log available
+updates for at most 2 tools defined in `.tool-versions` at the time.
+
+```yml
+name: Tooling
+on:
+  workflow_dispatch: ~
+
+permissions: read-all
+
+jobs:
+  tooling:
+    name: Update tooling
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3.0.0
+      - name: Update tooling
+        uses: ericcornelissen/tool-versions-update-action/commit@v0.2.0
+        with:
+          max: 2
+      - name: Log tooling changes
+        run: git diff .tool-versions
+```
+
+### Security
+
+#### Permissions
+
+This action requires no permissions.
+
+#### Network
+
+This action requires network access to all endpoints your [asdf] plugins use.
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,23 @@
+name: Tool Versions Update Action
+description: Update tools in your .tool-versions file
+branding:
+  icon: arrow-up-circle
+  color: blue
+
+inputs:
+  max:
+    description: |
+      The maximum number of tools to update. 0 indicates no maximum.
+    required: false
+    default: 0
+
+runs:
+  using: composite
+  steps:
+    - name: Install asdf
+      uses: asdf-vm/actions/install@v2
+    - name: Look for updates
+      shell: bash
+      run: $GITHUB_ACTION_PATH/bin/update.sh
+      env:
+        MAX: ${{ inputs.max }}


### PR DESCRIPTION
## Summary

Add a third version of the action at the base of the repository that is intended to _just_ update tooling and not do anything else. This will allow users to build custom workflows with their preferred automation (even allowing for alternative Pull Request or commit actions, not too mention providing control over updating said actions w.r.t. to the "batteries included" workflows offered).