### PR TITLE
Add missing `.tool-versions` file detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Add missing `.tool-versions` detection to each action.
 
 ## [0.2.1] - 2023-07-07
 

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -12,6 +12,10 @@ debug() {
 	echo "::debug::$1"
 }
 
+error() {
+	echo "::error::$1"
+}
+
 group_start() {
 	echo "::group::$1"
 }
@@ -26,6 +30,12 @@ group_end() {
 
 max_capacity=${MAX}
 remaining_capacity=${MAX}
+
+debug "checking if .tool-versions file exists"
+if [[ ! -f '.tool-versions' ]]; then
+	error "no .tool-versions file found, it must be present at the root of your project in order for this action to work"
+	exit 1
+fi
 
 group_start "Updating tools"
 debug "starting with update capacity: ${remaining_capacity}"


### PR DESCRIPTION
Closes #32

## Summary

Add a check to all actions in this project to detect if the project has a `.tool-versions` file and, if not, exit early with an information message.