### PR TITLE
Pre-install tooling in development image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ RUN apk add --no-cache \
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+WORKDIR /setup
+COPY .tool-versions .
+
 RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.11.1 \
 	&& echo '. "$HOME/.asdf/asdf.sh"' > ~/.bashrc \
 	&& . "$HOME/.asdf/asdf.sh" \
@@ -16,6 +19,7 @@ RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.11.1 \
 	&& asdf plugin add hadolint \
 	&& asdf plugin add shellcheck \
 	&& asdf plugin add shfmt \
-	&& asdf plugin add yamllint
+	&& asdf plugin add yamllint \
+	&& asdf install
 
 ENTRYPOINT ["/bin/bash"]

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,6 @@ $(ASDF): .tool-versions | $(TMP_DIR)
 	@asdf install
 	@touch $(ASDF)
 
-$(DEV_IMG): Dockerfile | $(TMP_DIR)
+$(DEV_IMG): .tool-versions Dockerfile | $(TMP_DIR)
 	@docker build --tag $(DEV_IMG_NAME) .
 	@touch $(DEV_IMG)


### PR DESCRIPTION
## Summary

Update the `Dockerfile` development image to install development tooling upon image creation by copying the `.tool-versions` file into the image and running `asdf install`. This streamlines development using this image by avoiding the need to re-install the tooling every time the image is used to create a ephemeral development environment.