### PR TITLE
Rename nightly tooling update workflow to narrow scope

### DIFF
--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -1,4 +1,4 @@
-name: Nightly
+name: Tooling
 on:
   schedule:
     - cron: 0 4 * * *
@@ -8,7 +8,7 @@ permissions: read-all
 
 jobs:
   tooling:
-    name: Update tooling
+    name: Update
     runs-on: ubuntu-22.04
     permissions:
       contents: write # To push a commit


### PR DESCRIPTION
Relates to #28

## Summary

The `nightly.yml` workflow only updates tooling. Rename the workflow to make it more explicit that this workflow is about updating tools. And also avoid potential confusion as other workflows (currently `semgrep.yml` and `secrets.yml`) run nightly as well.