### PR TITLE
Add `not:` input to all action variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning].
 
 ## [Unreleased]
 
+- Add input `not:` to exclude certain tools from being updated to each action.
 - Configure actions to exit immediately when an error occurs.
 
 ## [0.3.0] - 2023-07-15

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ The first stable release (if reached) will be v1.0.0.
     #
     # Default: 0
     max: 2
+
+    # A comma-separated list of tools that should NOT be updated.
+    #
+    # Default: ""
+    not: actionlint,shfmt
 ```
 
 ### Batteries Included

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,11 @@ inputs:
       The maximum number of tools to update. 0 indicates no maximum.
     required: false
     default: 0
+  not:
+    description: |
+      A comma-separated list of tools that should NOT be updated.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -19,3 +24,4 @@ runs:
       run: $GITHUB_ACTION_PATH/bin/update.sh
       env:
         MAX: ${{ inputs.max }}
+        NOT: ${{ inputs.not }}

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -5,6 +5,7 @@
 set -eo pipefail
 
 bin_dir=$(dirname "${BASH_SOURCE[0]}")
+exclusions=${NOT}
 max_capacity=${MAX}
 remaining_capacity=${MAX}
 
@@ -36,6 +37,13 @@ while read -r line; do
 		debug "processing line ('${line}')"
 
 		tool="$(echo "${line}" | awk '{print $1}')"
+
+		debug "checking if ${tool} should be evaluated"
+		if [[ ${exclusions} =~ (^|,)" "*"${tool}"" "*($|,) ]]; then
+			info "skipping ${tool} because it is configured in the exclusion rule"
+			continue
+		fi
+
 		info "evaluating ${tool}..."
 
 		current_version="$(echo "${line}" | awk '{print $2}')"

--- a/commit/README.md
+++ b/commit/README.md
@@ -18,6 +18,11 @@ file through a commit.
     # Default: 0
     max: 2
 
+    # A comma-separated list of tools that should NOT be updated.
+    #
+    # Default: ""
+    not: actionlint,shfmt
+
     # A list of newline-separated "plugin url" pairs that should be installed.
     # If omitted the default plugins will be available.
     #

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -15,6 +15,11 @@ inputs:
       The maximum number of tools to update. 0 indicates no maximum.
     required: false
     default: 0
+  not:
+    description: |
+      A comma-separated list of tools that should NOT be updated.
+    required: false
+    default: ""
   plugins:
     description: |
       A list of newline-separated "plugin url" pairs that should be installed.
@@ -54,6 +59,7 @@ runs:
       run: $GITHUB_ACTION_PATH/../bin/update.sh
       env:
         MAX: ${{ inputs.max }}
+        NOT: ${{ inputs.not }}
 
     - name: Create commit
       uses: stefanzweifel/git-auto-commit-action@v4

--- a/pr/README.md
+++ b/pr/README.md
@@ -18,6 +18,11 @@ file through a Pull Request.
     # Default: 0
     max: 2
 
+    # A comma-separated list of tools that should NOT be updated.
+    #
+    # Default: ""
+    not: actionlint,shfmt
+
     # A list of newline-separated "plugin url" pairs that should be installed.
     # If omitted the default plugins will be available.
     #

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -15,6 +15,11 @@ inputs:
       The maximum number of tools to update. 0 indicates no maximum.
     required: false
     default: 0
+  not:
+    description: |
+      A comma-separated list of tools that should NOT be updated.
+    required: false
+    default: ""
   plugins:
     description: |
       A list of newline-separated "plugin url" pairs that should be installed.
@@ -51,6 +56,7 @@ runs:
       run: $GITHUB_ACTION_PATH/../bin/update.sh
       env:
         MAX: ${{ inputs.max }}
+        NOT: ${{ inputs.not }}
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v5


### PR DESCRIPTION
Partially implements #7

## Summary

Update the `bin/update.sh` script with logic to not update certain tools if they're listed in a provided comma-separated list of exclusions. Each individual action has been updated with an option called `not:` that, optionally, can be used to define this list of exclusions.