### PR TITLE
Use latest major version number for `uses:` in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v3
       - name: Install asdf
-        uses: asdf-vm/actions/install@
+        uses: asdf-vm/actions/install@v2
       # Optionally configure asdf plugins depending on your needs.
       # - name: Configure asdf plugins
       #   run: |


### PR DESCRIPTION
## Summary

Update GitHub Actions workflows in the documentation to specify other actions being used in terms of the latest major version number (e.g. v1) in order to avoid having an outdated version of the action specified (of course this still requires updating the docs if a new major version of any of these actions is released, but that should be less frequent).

This also fixes a mistake introduced in #36 in the "Full Example" workflow in the root `README.md` which was missing a version number altogether for the use of `asdf-vm/actions/install`.