### PR TITLE
Add `only:` input to all action variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Add input `only:` to consider updating only certain tools to each action.
 
 ## [0.3.1] - 2023-07-16
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ The first stable release (if reached) will be v1.0.0.
     #
     # Default: ""
     not: actionlint,shfmt
+
+    # A comma-separated list of tools that should be updated, ignoring others.
+    #
+    # Default: ""
+    only: shellcheck
 ```
 
 ### Batteries Included

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,11 @@ inputs:
       A comma-separated list of tools that should NOT be updated.
     required: false
     default: ""
+  only:
+    description: |
+      A comma-separated list of tools that should be updated, ignoring others.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -25,3 +30,4 @@ runs:
       env:
         MAX: ${{ inputs.max }}
         NOT: ${{ inputs.not }}
+        ONLY: ${{ inputs.only }}

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -7,6 +7,7 @@ set -eo pipefail
 
 bin_dir=$(dirname "${BASH_SOURCE[0]}")
 exclusions=${NOT}
+inclusions=${ONLY}
 max_capacity=${MAX}
 remaining_capacity=${MAX}
 
@@ -43,6 +44,13 @@ while read -r line; do
 		if [[ ${exclusions} =~ (^|,)" "*"${tool}"" "*($|,) ]]; then
 			info "skipping ${tool} because it is configured in the exclusion rule"
 			continue
+		fi
+
+		if [[ -n ${inclusions} ]]; then
+			if [[ ! ${inclusions} =~ (^|,)" "*"${tool}"" "*($|,) ]]; then
+				info "skipping ${tool} because it is NOT configured in the inclusion rule"
+				continue
+			fi
 		fi
 
 		info "evaluating ${tool}..."

--- a/commit/README.md
+++ b/commit/README.md
@@ -23,6 +23,11 @@ file through a commit.
     # Default: ""
     not: actionlint,shfmt
 
+    # A comma-separated list of tools that should be updated, ignoring others.
+    #
+    # Default: ""
+    only: shellcheck
+
     # A list of newline-separated "plugin url" pairs that should be installed.
     # If omitted the default plugins will be available.
     #

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -20,6 +20,11 @@ inputs:
       A comma-separated list of tools that should NOT be updated.
     required: false
     default: ""
+  only:
+    description: |
+      A comma-separated list of tools that should be updated, ignoring others.
+    required: false
+    default: ""
   plugins:
     description: |
       A list of newline-separated "plugin url" pairs that should be installed.
@@ -60,6 +65,7 @@ runs:
       env:
         MAX: ${{ inputs.max }}
         NOT: ${{ inputs.not }}
+        ONLY: ${{ inputs.only }}
 
     - name: Create commit
       uses: stefanzweifel/git-auto-commit-action@v4

--- a/pr/README.md
+++ b/pr/README.md
@@ -23,6 +23,11 @@ file through a Pull Request.
     # Default: ""
     not: actionlint,shfmt
 
+    # A comma-separated list of tools that should be updated, ignoring others.
+    #
+    # Default: ""
+    only: shellcheck
+
     # A list of newline-separated "plugin url" pairs that should be installed.
     # If omitted the default plugins will be available.
     #

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -20,6 +20,11 @@ inputs:
       A comma-separated list of tools that should NOT be updated.
     required: false
     default: ""
+  only:
+    description: |
+      A comma-separated list of tools that should be updated, ignoring others.
+    required: false
+    default: ""
   plugins:
     description: |
       A list of newline-separated "plugin url" pairs that should be installed.
@@ -57,6 +62,7 @@ runs:
       env:
         MAX: ${{ inputs.max }}
         NOT: ${{ inputs.not }}
+        ONLY: ${{ inputs.only }}
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v5


### PR DESCRIPTION
Closes #7 
Relates to #42

## Summary

Update the `bin/update.sh` script with logic to update only certain tools as listed in a provided comma-separated list of inclusions. Each individual action has been updated with an option called `only:` that, optionally, can be used to define this list of inclusions.