### PR TITLE
Avoid `README.md` updates for releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The first stable release (if reached) will be v1.0.0.
 ## Usage
 
 ```yml
-- uses: ericcornelissen/tool-versions-update-action@v0.3.1
+- uses: ericcornelissen/tool-versions-update-action@v0
   with:
     # The maximum number of tools to update. 0 indicates no maximum.
     #
@@ -70,7 +70,7 @@ jobs:
       #   run: |
       #     asdf plugin add example https://github.com/ericcornelissen/asdf-example
       - name: Update tooling
-        uses: ericcornelissen/tool-versions-update-action/commit@v0.3.1
+        uses: ericcornelissen/tool-versions-update-action/commit@v0
         with:
           max: 2
       - name: Log tooling changes

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,9 +24,6 @@ found in this file (using v0.1.2 as an example):
    + 0.1.2
    ```
 
-1. Update all version numbers referenced in all `README.md`s to match the value
-   in the `.version` file.
-
 1. Update the changelog by manually adding the following after the
    `## [Unreleased]` line:
 
@@ -43,7 +40,7 @@ found in this file (using v0.1.2 as an example):
 
    ```shell
    git checkout -b release-$(sha1sum .version | awk '{print $1}')
-   git add .version CHANGELOG.md README.md commit/README.md pr/README.md
+   git add .version CHANGELOG.md
    git commit --message "Version bump"
    git push origin release-$(sha1sum .version | awk '{print $1}')
    ```

--- a/commit/README.md
+++ b/commit/README.md
@@ -6,7 +6,7 @@ file through a commit.
 ## Usage
 
 ```yml
-- uses: ericcornelissen/tool-versions-update-action/commit@v0.3.1
+- uses: ericcornelissen/tool-versions-update-action/commit@v0
   with:
     # The branch to commit to.
     #
@@ -62,7 +62,7 @@ jobs:
       contents: write
     steps:
       - name: Update tooling
-        uses: ericcornelissen/tool-versions-update-action/commit@v0.3.1
+        uses: ericcornelissen/tool-versions-update-action/commit@v0
         with:
           max: 2
 ```

--- a/pr/README.md
+++ b/pr/README.md
@@ -6,7 +6,7 @@ file through a Pull Request.
 ## Usage
 
 ```yml
-- uses: ericcornelissen/tool-versions-update-action/pr@v0.3.1
+- uses: ericcornelissen/tool-versions-update-action/pr@v0
   with:
     # A comma or newline-separated list of labels.
     #
@@ -63,7 +63,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Update tooling
-        uses: ericcornelissen/tool-versions-update-action/pr@v0.3.1
+        uses: ericcornelissen/tool-versions-update-action/pr@v0
         with:
           max: 2
 ```


### PR DESCRIPTION
## Summary

Update all `README.md`s to reference the current action by the major version only (same as external actions). This will avoid having to update the `README.md`s for every release without too much drawbacks. Users that want to use an exact version (or hash) still can, now it's just a different group of users that has to make changes to the provided examples when they use them.