### PR TITLE
Remove `-it` option from `update-actions` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,6 @@ lint-yml: $(ASDF) ## Lint YAML files
 .PHONY: update-actions
 update-actions: ## Update (and pin) all actions used by these actions
 	@docker run \
-		-it \
 		--rm \
 		--workdir "/tool-versions-update-action" \
 		--mount "type=bind,source=$(shell pwd),target=/tool-versions-update-action" \


### PR DESCRIPTION
Followup to #50

## Summary

Remove unnecessary `-it` from the `update-actions` target which [breaks](https://github.com/ericcornelissen/tool-versions-update-action/actions/runs/5604170186) the `transitive-actions.yml` workflow.
