### PR TITLE
Add inputs to configure messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning].
 
 ## [Unreleased]
 
+- Add `commit-message` input to `tool-versions-update-action/commit` and
+  `tool-versions-update-action/pr`.
 - Pin all actions used by these actions.
 
 ## [0.3.2] - 2023-07-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning].
 
 - Add `commit-message` input to `tool-versions-update-action/commit` and
   `tool-versions-update-action/pr`.
+- Add `pr-title` and `pr-body` inputs to `tool-versions-update-action/pr`.
 - Pin all actions used by these actions.
 
 ## [0.3.2] - 2023-07-18

--- a/commit/README.md
+++ b/commit/README.md
@@ -13,6 +13,11 @@ file through a commit.
     # Default: *current or default branch*
     branch: develop
 
+    # The message to use for update commits.
+    #
+    # Default: Update .tool-versions
+    commit-message: Update tooling
+
     # The maximum number of tools to update. 0 indicates no maximum.
     #
     # Default: 0

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -10,6 +10,11 @@ inputs:
       The branch to commit to.
     required: false
     default: ${{ github.head_ref }}
+  commit-message:
+    description: |
+      The message to use for update commits.
+    required: false
+    default: Update .tool-versions
   max:
     description: |
       The maximum number of tools to update. 0 indicates no maximum.
@@ -76,4 +81,4 @@ runs:
         branch: ${{ inputs.branch }}
 
         # Commit
-        commit_message: Update `.tool-versions`
+        commit_message: ${{ inputs.commit-message }}

--- a/pr/README.md
+++ b/pr/README.md
@@ -8,6 +8,11 @@ file through a Pull Request.
 ```yml
 - uses: ericcornelissen/tool-versions-update-action/pr@v0
   with:
+    # The message to use for update commits.
+    #
+    # Default: Update .tool-versions
+    commit-message: Update tooling
+
     # A comma or newline-separated list of labels.
     #
     # Default: *no labels*

--- a/pr/README.md
+++ b/pr/README.md
@@ -41,6 +41,17 @@ file through a Pull Request.
       actionlint https://github.com/crazy-matt/asdf-actionlint
       shellcheck https://github.com/luizm/asdf-shellcheck
 
+    # The body text to use for Pull Requests.
+    #
+    # Default: Bump tools in `.tool-versions`
+    pr-body: |
+      _This Pull Request was generated using the `tool-versions-update-action`_
+
+    # The title to use for Pull Requests.
+    #
+    # Default: Update `.tool-versions`
+    pr-title: Update tooling
+
     # The $GITHUB_TOKEN or a repository scoped Personal Access Token (PAT).
     #
     # Default: $GITHUB_TOKEN

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -36,6 +36,16 @@ inputs:
       If omitted the default plugins will be available.
     required: false
     default: ""
+  pr-body:
+    description: |
+      The body text to use for Pull Requests.
+    required: false
+    default: Bump tools in `.tool-versions`
+  pr-title:
+    description: |
+      The title to use for Pull Requests.
+    required: false
+    default: Update `.tool-versions`
   token:
     description: |
       The $GITHUB_TOKEN or a repository scoped Personal Access Token (PAT).
@@ -75,8 +85,8 @@ runs:
         token: ${{ inputs.token }}
 
         # Pull Request
-        title: Update `.tool-versions`
-        body: Bump tools in `.tool-versions`
+        title: ${{ inputs.pr-title }}
+        body: ${{ inputs.pr-body }}
         labels: ${{ inputs.labels }}
 
         # Branch

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -5,6 +5,11 @@ branding:
   color: blue
 
 inputs:
+  commit-message:
+    description: |
+      The message to use for update commits.
+    required: false
+    default: Update .tool-versions
   labels:
     description: |
       A comma or newline-separated list of labels.
@@ -78,5 +83,5 @@ runs:
         branch: tool-versions-updates
 
         # Commit
-        commit-message: Update .tool-versions
+        commit-message: ${{ inputs.commit-message }}
         add-paths: .tool-versions


### PR DESCRIPTION
Closes #12 
Closes #13
Closes #22

## Summary

Add the input `commit-message` to both the [`/commit`](https://github.com/ericcornelissen/tool-versions-update-action/tree/8a3b847ec589e0e36f038feed4435b624e8fe1c0/commit) and [`/pr`](https://github.com/ericcornelissen/tool-versions-update-action/tree/8a3b847ec589e0e36f038feed4435b624e8fe1c0/pr) variants of this action to allow users to customize the commit message of the tooling update commit.

Also add the inputs `pr-title` and `pr-body` to the [`/pr`](https://github.com/ericcornelissen/tool-versions-update-action/tree/8a3b847ec589e0e36f038feed4435b624e8fe1c0/pr) variant of this action to allow users to customize the copy of the tooling update Pull Request.