### PR TITLE
Explicitly set the files to commit

### DIFF
--- a/commit/action.yml
+++ b/commit/action.yml
@@ -82,3 +82,4 @@ runs:
 
         # Commit
         commit_message: ${{ inputs.commit-message }}
+        file_pattern: .tool-versions


### PR DESCRIPTION
## Summary

[Like for the `/pr` action](https://github.com/ericcornelissen/tool-versions-update-action/blob/dce7e8e82ec984d2fc6f10169c39b0812f8ab932/pr/action.yml#L97), update the [`/commit` action](https://github.com/ericcornelissen/tool-versions-update-action/tree/dce7e8e82ec984d2fc6f10169c39b0812f8ab932/commit) with an explicit list of files to commit. This is simply to avoid files that unexpectedly show up during action execution from being included in the commit.