### PR TITLE
Set up `actions/labeler` for automated Pull Request labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,32 @@
+# Check out Labeler at: https://github.com/actions/labeler
+
+action:base:
+  - action.yml
+
+action:commit:
+  - commit/*
+
+action:pr:
+  - pr/*
+
+ci/cd:
+  - .github/workflows/*
+  - .github/dependabot.yml
+  - .github/labeler.yml
+
+dependencies:
+  - .tool-versions
+
+documentation:
+  - commit/README.md
+  - pr/README.md
+  - README.md
+
+meta:
+  - .github/dependabot.yml
+  - .github/labeler.yml
+  - .editorconfig
+  - .gitattributes
+  - .hadolint.yml
+  - .shellcheckrc
+  - .yamllint.yml

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: Labeler
+on:
+  pull_request_target: ~
+
+permissions: read-all
+
+jobs:
+  label:
+    name: Label
+    permissions:
+      pull-requests: write # To assign labels
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Set labels on Pull Request
+        uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # v4.3.0
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: ""

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@
 !/.gitignore
 
 ## GitHub Actions
-!action.yml
+!/action.yml
 !/commit/
 /commit/**
 !/commit/action.yml
@@ -42,6 +42,7 @@
 !/.github/
 /.github/**
 !/.github/dependabot.yml
+!/.github/labeler.yml
 !/.github/workflows
 /.github/workflows/**
 !/.github/workflows/*.yml


### PR DESCRIPTION
## Summary

Set up [`actions/labeler`](https://github.com/actions/labeler) for automated Pull Request labeling.

NOTE: The `sync-labels: ""` option is necessary as such to avoid labeler removing labels it shouldn't remove (e.g. those assigned by a maintainer that fall outside of the labeler configuration). Other values for this option don't have the desired effect.