### PR TITLE
Add input `pr-base`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning].
 
 ## [Unreleased]
 
-- _No changes yet_
+- Add `pr-base` input to `tool-versions-update-action/pr`.
 
 ## [0.3.3] - 2023-07-22
 

--- a/pr/README.md
+++ b/pr/README.md
@@ -41,6 +41,11 @@ file through a Pull Request.
       actionlint https://github.com/crazy-matt/asdf-actionlint
       shellcheck https://github.com/luizm/asdf-shellcheck
 
+    # The base branch to use for Pull Requests.
+    #
+    # Default: *current branch*
+    pr-base: develop
+
     # The body text to use for Pull Requests.
     #
     # Default: Bump tools in `.tool-versions`

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -36,6 +36,11 @@ inputs:
       If omitted the default plugins will be available.
     required: false
     default: ""
+  pr-base:
+    description: |
+      The base branch to use for Pull Requests.
+    required: false
+    default: ${{ github.head_ref }}
   pr-body:
     description: |
       The body text to use for Pull Requests.
@@ -87,6 +92,7 @@ runs:
         # Pull Request
         title: ${{ inputs.pr-title }}
         body: ${{ inputs.pr-body }}
+        base: ${{ inputs.pr-base }}
         labels: ${{ inputs.labels }}
 
         # Branch


### PR DESCRIPTION
Closes #56

## Summary

Add the input `pr-base` to the /pr variant of this action to allow users to customize the Pull Request base branch of tooling update Pull Requests.