### PR TITLE
Group changes by action in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,49 +10,126 @@ Versioning].
 
 - _No changes yet_
 
+### `tool-versions-update-action`
+
+- _No changes yet_
+
+### `tool-versions-update-action/commit`
+
+- _No changes yet_
+
+### `tool-versions-update-action/pr`
+
+- _No changes yet_
+
 ## [0.3.3] - 2023-07-22
 
-- Add `commit-message` input to `tool-versions-update-action/commit` and
-  `tool-versions-update-action/pr`.
-- Add `pr-title` and `pr-body` inputs to `tool-versions-update-action/pr`.
-- Pin all actions used by these actions.
+### `tool-versions-update-action`
+
+- _Version bump only._
+
+### `tool-versions-update-action/commit`
+
+- Add input `commit-message` to configure the commit message.
+- Pin all actions used by this action.
+
+### `tool-versions-update-action/pr`
+
+- Add input `commit-message` to configure the commit message.
+- Add input `pr-body` to configure the Pull Request description.
+- Add input `pr-title`  to configure the Pull Request title.
+- Pin all actions used by this action.
 
 ## [0.3.2] - 2023-07-18
 
-- Add input `only:` to consider updating only certain tools to each action.
+### `tool-versions-update-action`
+
+- Add input `only` to consider updating only certain tools.
+
+### `tool-versions-update-action/commit`
+
+- Add input `only` to consider updating only certain tools.
+
+### `tool-versions-update-action/pr`
+
+- Add input `only` to consider updating only certain tools.
 
 ## [0.3.1] - 2023-07-16
 
-- Add input `not:` to exclude certain tools from being updated to each action.
-- Configure actions to exit immediately when an error occurs.
+### `tool-versions-update-action`
+
+- Add input `not` to exclude certain tools from being updated.
+- Exit immediately when an error occurs.
+
+### `tool-versions-update-action/commit`
+
+- Add input `not` to exclude certain tools from being updated.
+- Exit immediately when an error occurs.
+
+### `tool-versions-update-action/pr`
+
+- Add input `not` to exclude certain tools from being updated.
+- Exit immediately when an error occurs.
 
 ## [0.3.0] - 2023-07-15
 
-- BREAKING: action at `tool-versions-update-action` no longer install asdf.
-- Add missing `.tool-versions` detection to each action.
-- Add `plugins` option to `tool-versions-update-action/commit`.
-- Add `plugins` option to `tool-versions-update-action/pr`.
+### `tool-versions-update-action`
+
+- BREAKING: No longer installs asdf.
+- Add missing `.tool-versions` detection.
+
+### `tool-versions-update-action/commit`
+
+- Add input `plugins` to install asdf plugins.
+- Add missing `.tool-versions` detection.
+
+### `tool-versions-update-action/pr`
+
+- Add input `plugins` to install asdf plugins.
+- Add missing `.tool-versions` detection.
 
 ## [0.2.1] - 2023-07-07
 
-- Add action that just updates tools at `tool-versions-update-action`.
-- Add labels option to `tool-versions-update-action/pr`.
+### `tool-versions-update-action`
+
+- _Initial release._
+
+### `tool-versions-update-action/commit`
+
+- _Version bump only._
+
+### `tool-versions-update-action/pr`
+
+- Add input `labels` to configure the initial labels on Pull Requests.
 
 ## [0.2.0] - 2023-06-18
 
-- BREAKING: action moved to `ericcornelissen/tool-versions-update-action/pr`.
-- Add new action `ericcornelissen/tool-versions-update-action/commit`.
+### `tool-versions-update-action`
+
+- BREAKING: Moved to `tool-versions-update-action/pr`.
+
+### `tool-versions-update-action/comment`
+
+- _Initial release._
+
+### `tool-versions-update-action/pr`
+
+- BREAKING: Moved from `tool-versions-update-action`.
 - Add log grouping.
 - Improve debug logs with more details.
 
 ## [0.1.1] - 2023-06-17
+
+### `tool-versions-update-action`
 
 - Fix creating multiple Pull Requests.
 - Fix logging format & hide debug logs by default.
 
 ## [0.1.0] - 2023-06-15
 
-- Initial release.
+### `tool-versions-update-action`
+
+- _Initial release._
 
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html


### PR DESCRIPTION
## Summary

Since the introduction of more than one action into this repository, the changelog has been a bit messy. This change aims to reduce the messiness by grouping changes by the action to which it applies per version.