### PR TITLE
Add testing in CI as well as using `act`

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,5 @@
+# Check out act at: https://github.com/nektos/act
+
+--platform ubuntu-22.04=ghcr.io/catthehacker/ubuntu:act-22.04
+--quiet
+--use-gitignore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+on:
+  pull_request: ~
+  push:
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  test-bare:
+    name: Bare action
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Install tooling
+        uses: asdf-vm/actions/install@6a442392015fbbdd8b48696d41e0051b2698b2e4 # v2.2.0
+      - name: Run bare action
+        uses: ./

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 !/Makefile
 
 ## Configuration
+!/.actrc
 !/.editorconfig
 !/.hadolint.yml
 !/.shellcheckrc

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,6 +2,7 @@
 # - asdf: https://asdf-vm.com/
 # - rtx: https://github.com/jdxcode/rtx
 
+act 0.2.49
 actionlint 1.6.25
 hadolint 2.12.0
 shellcheck 0.9.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY .tool-versions .
 RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.11.1 \
 	&& echo '. "$HOME/.asdf/asdf.sh"' > ~/.bashrc \
 	&& . "$HOME/.asdf/asdf.sh" \
+	&& asdf plugin add act \
 	&& asdf plugin add actionlint \
 	&& asdf plugin add hadolint \
 	&& asdf plugin add shellcheck \

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,10 @@ lint-sh: $(ASDF) ## Lint shell scripts
 lint-yml: $(ASDF) ## Lint YAML files
 	@yamllint -c .yamllint.yml .
 
+.PHONY: test-e2e
+test-e2e: ## Run end-to-end tests
+	@act --job test-bare
+
 .PHONY: update-actions
 update-actions: ## Update (and pin) all actions used by these actions
 	@docker run \


### PR DESCRIPTION
## Summary

Create a CI workflow that runs a basic smoke test by simply running the bare action the current repository. This smoke test is run for Pull Requests and commits on `main` as a (initial) basic sanity check.

Also add direct support for using [`act`](https://github.com/nektos/act) to run these tests locally.