### PR TITLE
Add input `assignees`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning].
 
 ### `tool-versions-update-action/pr`
 
+- Add input `assignees` to configure the user(s) assigned to the Pull Request.
 - Add output `pr-number`.
 
 ## [0.3.4] - 2023-08-03

--- a/pr/README.md
+++ b/pr/README.md
@@ -8,6 +8,12 @@ file through a Pull Request.
 ```yml
 - uses: ericcornelissen/tool-versions-update-action/pr@v0
   with:
+    # A comma or newline-separated list of assignees for the Pull Request (by
+    # their GitHub username).
+    #
+    # Default: ""
+    assignees: ericcornelissen
+
     # The message to use for update commits.
     #
     # Default: Update .tool-versions

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -5,6 +5,12 @@ branding:
   color: blue
 
 inputs:
+  assignees:
+    description: |
+      A comma or newline-separated list of assignees for the Pull Request (by
+      their GitHub username).
+    required: false
+    default: ""
   commit-message:
     description: |
       The message to use for update commits.
@@ -103,6 +109,7 @@ runs:
         title: ${{ inputs.pr-title }}
         body: ${{ inputs.pr-body }}
         base: ${{ inputs.pr-base }}
+        assignees: ${{ inputs.assignees }}
         labels: ${{ inputs.labels }}
 
         # Branch


### PR DESCRIPTION
Closes #58

## Summary

Add the input `assignees` to the /pr variant of this action to allow users to customize the Pull Request assignees on creation of the tooling update Pull Requests.