### PR TITLE
Add output `commit-sha`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,12 @@ Versioning].
 
 ### `tool-versions-update-action/commit`
 
-- _No changes yet._
+- Add output `commit-sha`.
 
 ### `tool-versions-update-action/pr`
 
 - Add input `assignees` to configure the user(s) assigned to the Pull Request.
+- Add output `commit-sha`.
 - Add output `pr-number`.
 
 ## [0.3.4] - 2023-08-03

--- a/commit/README.md
+++ b/commit/README.md
@@ -53,6 +53,7 @@ The following outputs are made available:
 
 | Name         | Description                                                |
 | ------------ | ---------------------------------------------------------- |
+| `commit-sha` | The SHA identifier of the created commit                   |
 | `did-update` | `true` if at least one tool was updated, `false` otherwise |
 
 ### Full Example

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -43,8 +43,11 @@ inputs:
     default: ${{ github.token }}
 
 outputs:
+  commit-sha:
+    description: The SHA identifier of the created commit.
+    value: ${{ steps.create-commit.outputs.commit_hash }}
   did-update:
-    description: true if at least one tool was updated, false otherwise
+    description: true if at least one tool was updated, false otherwise.
     value: ${{ steps.update.outputs.did-update }}
 
 runs:
@@ -79,6 +82,7 @@ runs:
         ONLY: ${{ inputs.only }}
 
     - name: Create commit
+      id: create-commit
       uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # pin@v4
       with:
         skip_dirty_check: false

--- a/pr/README.md
+++ b/pr/README.md
@@ -75,6 +75,7 @@ The following outputs are made available:
 
 | Name         | Description                                                |
 | ------------ | ---------------------------------------------------------- |
+| `commit-sha` | The SHA identifier of the created commit                   |
 | `did-update` | `true` if at least one tool was updated, `false` otherwise |
 | `pr-number`  | The number of the created Pull Request                     |
 

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -64,11 +64,14 @@ inputs:
     default: ${{ github.token }}
 
 outputs:
+  commit-sha:
+    description: The SHA identifier of the created commit.
+    value: ${{ steps.create-pr.outputs.pull-request-head-sha }}
   did-update:
-    description: true if at least one tool was updated, false otherwise
+    description: true if at least one tool was updated, false otherwise.
     value: ${{ steps.update.outputs.did-update }}
   pr-number:
-    description: The number of the created Pull Request
+    description: The number of the created Pull Request.
     value: ${{ steps.create-pr.outputs.pull-request-number }}
 
 runs:


### PR DESCRIPTION
Relates to #62

## Summary

Add the `commit-sha` output to both the `/commit` action and the `/pr` action.