### PR TITLE
Add link on how to use action outputs to "Outputs" sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The following outputs are made available:
 | ------------ | ---------------------------------------------------------- |
 | `did-update` | `true` if at least one tool was updated, `false` otherwise |
 
+For information on how to use outputs see the [GitHub Actions output docs].
+
 ### Full Example
 
 This example is for a workflow that can be triggered manually to log available
@@ -105,4 +107,5 @@ license text. The contents of documentation is licensed under [CC BY 4.0].
 [asdf]: https://asdf-vm.com/
 [cc by 4.0]: https://creativecommons.org/licenses/by/4.0/
 [github actions]: https://github.com/features/actions
+[github actions output docs]: https://help.github.com/en/actions/reference/contexts-and-expression-syntax-for-github-actions#steps-context
 [license]: ./LICENSE

--- a/commit/README.md
+++ b/commit/README.md
@@ -55,6 +55,8 @@ The following outputs are made available:
 | ------------ | ---------------------------------------------------------- |
 | `did-update` | `true` if at least one tool was updated, `false` otherwise |
 
+For information on how to use outputs see the [GitHub Actions output docs].
+
 ### Full Example
 
 This example is for a workflow that can be triggered manually to create a commit
@@ -109,3 +111,4 @@ The contents of this document are licensed under [CC BY 4.0].
 [asdf]: https://asdf-vm.com/
 [cc by 4.0]: https://creativecommons.org/licenses/by/4.0/
 [github action]: https://github.com/features/actions
+[github actions output docs]: https://help.github.com/en/actions/reference/contexts-and-expression-syntax-for-github-actions#steps-context

--- a/pr/README.md
+++ b/pr/README.md
@@ -78,6 +78,8 @@ The following outputs are made available:
 | `did-update` | `true` if at least one tool was updated, `false` otherwise |
 | `pr-number`  | The number of the created Pull Request                     |
 
+For information on how to use outputs see the [GitHub Actions output docs].
+
 ### Full Example
 
 This example is for a workflow that can be triggered manually to create a Pull
@@ -134,3 +136,4 @@ The contents of this document are licensed under [CC BY 4.0].
 [asdf]: https://asdf-vm.com/
 [cc by 4.0]: https://creativecommons.org/licenses/by/4.0/
 [github action]: https://github.com/features/actions
+[github actions output docs]: https://help.github.com/en/actions/reference/contexts-and-expression-syntax-for-github-actions#steps-context


### PR DESCRIPTION
Relates to #62

## Summary

Improve upon the "Outputs" section added in #68 with a link to the GitHub documentation explaining how outputs can be used.