### PR TITLE
Add input `reviewers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning].
 ### `tool-versions-update-action/pr`
 
 - Add input `assignees` to configure the user(s) assigned to the Pull Request.
+- Add input `reviewers` to configure the user(s) to review the Pull Request.
 - Add output `commit-sha`.
 - Add output `pr-number`.
 

--- a/pr/README.md
+++ b/pr/README.md
@@ -63,6 +63,12 @@ file through a Pull Request.
     # Default: Update `.tool-versions`
     pr-title: Update tooling
 
+    # A comma or newline-separated list of reviewers for the Pull Request (by
+    # their GitHub username).
+    #
+    # Default: ""
+    reviewers: ericcornelissen
+
     # The $GITHUB_TOKEN or a repository scoped Personal Access Token (PAT).
     #
     # Default: $GITHUB_TOKEN

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -57,6 +57,12 @@ inputs:
       The title to use for Pull Requests.
     required: false
     default: Update `.tool-versions`
+  reviewers:
+    description: |
+      A comma or newline-separated list of reviewers for the Pull Request (by
+      their GitHub username).
+    required: false
+    default: ""
   token:
     description: |
       The $GITHUB_TOKEN or a repository scoped Personal Access Token (PAT).
@@ -112,6 +118,7 @@ runs:
         title: ${{ inputs.pr-title }}
         body: ${{ inputs.pr-body }}
         base: ${{ inputs.pr-base }}
+        reviewers: ${{ inputs.reviewers }}
         assignees: ${{ inputs.assignees }}
         labels: ${{ inputs.labels }}
 


### PR DESCRIPTION
Closes #59

## Summary

Add the input `reviewers` to the /pr variant of this action to allow users to customize the Pull Request reviewers on creation of the tooling update Pull Requests.