### PR TITLE
Add input `branch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Versioning].
 
 ### `tool-versions-update-action/pr`
 
-- _No changes yet._
+- Add input `branch` to configure the branch name for the Pull Request.
 
 ## [0.3.5] - 2023-08-19
 

--- a/pr/README.md
+++ b/pr/README.md
@@ -14,6 +14,11 @@ file through a Pull Request.
     # Default: ""
     assignees: ericcornelissen
 
+    # The branch name to use for Pull Requests.
+    #
+    # Default: "tool-versions-updates"
+    branch: update-tooling
+
     # The message to use for commits.
     #
     # Default: "Update .tool-versions"

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -11,6 +11,11 @@ inputs:
       GitHub username).
     required: false
     default: ""
+  branch:
+    description: |
+      The branch name to use for Pull Requests.
+    required: false
+    default: tool-versions-updates
   commit-message:
     description: |
       The message to use for commits.
@@ -123,7 +128,7 @@ runs:
         labels: ${{ inputs.labels }}
 
         # Branch
-        branch: tool-versions-updates
+        branch: ${{ inputs.branch }}
 
         # Commit
         commit-message: ${{ inputs.commit-message }}


### PR DESCRIPTION
Closes #57

## Summary


Add the input `branch` to the /pr variant of this action to allow users to customize the branch name for tooling update Pull Requests.