### PR TITLE
Consistently quote default string values for action inputs

### DIFF
--- a/commit/README.md
+++ b/commit/README.md
@@ -15,7 +15,7 @@ file through a commit.
 
     # The message to use for commits.
     #
-    # Default: Update .tool-versions
+    # Default: "Update .tool-versions"
     commit-message: Update tooling
 
     # The maximum number of tools to update. 0 indicates no maximum.

--- a/pr/README.md
+++ b/pr/README.md
@@ -16,7 +16,7 @@ file through a Pull Request.
 
     # The message to use for commits.
     #
-    # Default: Update .tool-versions
+    # Default: "Update .tool-versions"
     commit-message: Update tooling
 
     # A comma or newline-separated list of labels for Pull Requests.
@@ -54,13 +54,13 @@ file through a Pull Request.
 
     # The body text to use for Pull Requests.
     #
-    # Default: Bump tools in `.tool-versions`
+    # Default: "Bump tools in `.tool-versions`"
     pr-body: |
       _This Pull Request was generated using the `tool-versions-update-action`_
 
     # The title to use for Pull Requests.
     #
-    # Default: Update `.tool-versions`
+    # Default: "Update `.tool-versions`"
     pr-title: Update tooling
 
     # A comma or newline-separated list of reviewers for Pull Requests (by their


### PR DESCRIPTION
Relates to #80
Caused by #82

## Summary

Update the default documented value formatting for all inputs that are strings to use quoted. This was already the case for when the default value is an empty string. Doing it for non-empty strings as well makes it consistent as well as distinguishes it from "descriptive" default such as `*current or default branch*`.