### PR TITLE
Try `asdf-vm/action` on Node.js v20

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       - name: Install tooling
-        uses: asdf-vm/actions/install@6a442392015fbbdd8b48696d41e0051b2698b2e4 # v2.2.0
+        uses: asdf-vm/actions/install@a2d44a72f9174b83e100b92d27851c62696fa87c # rc-node-v20
       - name: Lint
         run: make lint-ci
   dev-img:
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       - name: Install tooling
-        uses: asdf-vm/actions/install@6a442392015fbbdd8b48696d41e0051b2698b2e4 # v2.2.0
+        uses: asdf-vm/actions/install@a2d44a72f9174b83e100b92d27851c62696fa87c # rc-node-v20
       - name: Lint
         run: make lint-docker
       - name: Build
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       - name: Install tooling
-        uses: asdf-vm/actions/install@6a442392015fbbdd8b48696d41e0051b2698b2e4 # v2.2.0
+        uses: asdf-vm/actions/install@a2d44a72f9174b83e100b92d27851c62696fa87c # rc-node-v20
       - name: Lint
         run: make lint-sh
       - name: Format
@@ -49,6 +49,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       - name: Install tooling
-        uses: asdf-vm/actions/install@6a442392015fbbdd8b48696d41e0051b2698b2e4 # v2.2.0
+        uses: asdf-vm/actions/install@a2d44a72f9174b83e100b92d27851c62696fa87c # rc-node-v20
       - name: Lint
         run: make lint-yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       - name: Install tooling
-        uses: asdf-vm/actions/install@6a442392015fbbdd8b48696d41e0051b2698b2e4 # v2.2.0
+        uses: asdf-vm/actions/install@a2d44a72f9174b83e100b92d27851c62696fa87c # rc-node-v20
       - name: Run bare action
         uses: ./


### PR DESCRIPTION
Relates to #94

## Summary

This Pull Request upgrades `asdf-vm/action` to an unreleased version that runs on Node.js v20.