### PR TITLE
Add SPDX license identifiers to documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Changelog
 
 All notable changes to _Tool Versions Update Action_ will be documented in this

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Contributing Guidelines
 
 The maintainers of the _Tool Versions Update Action_ welcome contributions and

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
 # Tool Versions Update Action
 
 A collection of [GitHub Actions] to automatically update the tools in your

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Release Guidelines
 
 To release a new version of the _Tool Versions Update Action_ follow the steps

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC0-1.0 -->
+
 # Security Policy
 
 The maintainers of the _Tool Versions Update Action_ project take security

--- a/commit/README.md
+++ b/commit/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
 # Tool Versions Update Action - Commit
 
 A [GitHub Action] to automatically update the tools in your `.tool-versions`

--- a/pr/README.md
+++ b/pr/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
 # Tool Versions Update Action - Pull Request
 
 A [GitHub Action] to automatically update the tools in your `.tool-versions`


### PR DESCRIPTION
Relates to #44

## Summary

Add license identifiers following the [SPDX license id format](https://spdx.dev/ids/) to all documentation files.