### PR TITLE
Extend v0 EOL by two months

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ with security updates.
 
 | Version | End-of-life                        |
 | ------: | :--------------------------------- |
-|   0.x.x | 2023-09-30 _or_ upon release 1.0.0 |
+|   0.x.x | 2023-11-30 _or_ upon release 1.0.0 |
 
 _This table only includes information on versions `<1.0.0`._
 


### PR DESCRIPTION
## Summary

The initial EOL date for this project was set to today (September 30, 2023) (or the release of v1). At this point I intend to carry on with this project, but currently do not yet feel ready to release v1. Hence, this extends the lifetime of v0 of the project by another 2 months.