### PR TITLE
Bump `stefanzweifel/git-auto-commit-action` from v4 to v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,14 @@ Versioning].
 
 ### `tool-versions-update-action/commit`
 
-- BREAKING: Bump `actions/checkout` from v3.6.0 to v4.1.0.
+- BREAKING: Require support for the Node.js v20 runtime from the Actions runner.
+- Bump `actions/checkout` from v3.6.0 to v4.1.0.
+- Bump `stefanzweifel/git-auto-commit-action` from v4.16.0 to v5.0.0.
 
 ### `tool-versions-update-action/pr`
 
-- BREAKING: Bump `actions/checkout` from v3.6.0 to v4.1.0.
+- BREAKING: Require support for the Node.js v20 runtime from the Actions runner.
+- Bump `actions/checkout` from v3.6.0 to v4.1.0.
 
 ## [0.3.6] - 2023-09-12
 

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -83,7 +83,7 @@ runs:
 
     - name: Create commit
       id: create-commit
-      uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # pin@v4
+      uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d # pin@v5
       with:
         skip_dirty_check: false
 


### PR DESCRIPTION
Relates to #92, #94

## Summary

Bump [`stefanzweifel/git-auto-commit-action`](https://github.com/stefanzweifel/git-auto-commit-action) as a transitive action from v4 to v5. As this is a major version bump (due to the runtime bump from Node.js v16 to Node.js v20), this should be released as a pre-v1 major version bump as well.