### PR TITLE
Bump `asdf-vm/actions` from v2 to v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,14 @@ Versioning].
 
 - BREAKING: Require support for the Node.js v20 runtime from the Actions runner.
 - Bump `actions/checkout` from v3.6.0 to v4.1.0.
+- Bump `asdf-vm/actions` from v2.2.0 to v3.0.0.
 - Bump `stefanzweifel/git-auto-commit-action` from v4.16.0 to v5.0.0.
 
 ### `tool-versions-update-action/pr`
 
 - BREAKING: Require support for the Node.js v20 runtime from the Actions runner.
 - Bump `actions/checkout` from v3.6.0 to v4.1.0.
+- Bump `asdf-vm/actions` from v2.2.0 to v3.0.0.
 
 ## [0.3.6] - 2023-09-12
 

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -61,7 +61,7 @@ runs:
 
     - name: Setup asdf
       if: ${{ inputs.plugins != '' }}
-      uses: asdf-vm/actions/setup@6a442392015fbbdd8b48696d41e0051b2698b2e4 # pin@v2
+      uses: asdf-vm/actions/setup@4f8f7939dd917fc656bb7c3575969a5988c28364 # pin@v3
     - name: Configure asdf plugins
       if: ${{ inputs.plugins != '' }}
       shell: bash
@@ -70,7 +70,7 @@ runs:
         LIST: ${{ inputs.plugins }}
 
     - name: Install asdf
-      uses: asdf-vm/actions/install@6a442392015fbbdd8b48696d41e0051b2698b2e4 # pin@v2
+      uses: asdf-vm/actions/install@4f8f7939dd917fc656bb7c3575969a5988c28364 # pin@v3
 
     - name: Look for updates
       id: update

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -93,7 +93,7 @@ runs:
 
     - name: Setup asdf
       if: ${{ inputs.plugins != '' }}
-      uses: asdf-vm/actions/setup@6a442392015fbbdd8b48696d41e0051b2698b2e4 # pin@v2
+      uses: asdf-vm/actions/setup@4f8f7939dd917fc656bb7c3575969a5988c28364 # pin@v3
     - name: Configure asdf plugins
       if: ${{ inputs.plugins != '' }}
       shell: bash
@@ -102,7 +102,7 @@ runs:
         LIST: ${{ inputs.plugins }}
 
     - name: Install asdf
-      uses: asdf-vm/actions/install@6a442392015fbbdd8b48696d41e0051b2698b2e4 # pin@v2
+      uses: asdf-vm/actions/install@4f8f7939dd917fc656bb7c3575969a5988c28364 # pin@v3
 
     - name: Look for updates
       id: update


### PR DESCRIPTION
Relates to #92, #94, #107, #108

## Summary

Bump [`asdf-vm/actions`](https://github.com/asdf-vm/actions) as a transitive action from v2 to v3. As this is a major version bump (due to the runtime bump from Node.js v16 to Node.js v20), this should be released as a pre-v1 major version bump as well.