### PR TITLE
Refactor `did-output`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
 outputs:
   did-update:
     description: true if at least one tool was updated, false otherwise.
-    value: ${{ steps.update.outputs.did-update }}
+    value: ${{ steps.update.outputs.updated-count != '0' }}
   updated-count:
     description: The number of tools that were updated.
     value: ${{ steps.update.outputs.updated-count }}

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -20,7 +20,6 @@ source "${bin_dir}/../lib/actions.sh"
 # --- Script ----------------------------------------------------------------- #
 
 debug "initializing outputs to their default value"
-set_output 'did-update' 'false'
 set_output 'updated-count' "${updated_count}"
 
 debug "checking if .tool-versions file exists"
@@ -71,9 +70,6 @@ while read -r line; do
 			asdf install "${tool}" "${latest_version}"
 			debug "applying ${tool}@${latest_version} locally"
 			asdf local "${tool}" "${latest_version}"
-
-			debug "overriding 'did-update' output to true"
-			set_output 'did-update' 'true'
 
 			debug "overriding 'updated-count' output with new value"
 			((updated_count += 1))

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -48,7 +48,7 @@ outputs:
     value: ${{ steps.create-commit.outputs.commit_hash }}
   did-update:
     description: true if at least one tool was updated, false otherwise.
-    value: ${{ steps.update.outputs.did-update }}
+    value: ${{ steps.update.outputs.updated-count != '0' }}
   updated-count:
     description: The number of tools that were updated.
     value: ${{ steps.update.outputs.updated-count }}

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -80,7 +80,7 @@ outputs:
     value: ${{ steps.create-pr.outputs.pull-request-head-sha }}
   did-update:
     description: true if at least one tool was updated, false otherwise.
-    value: ${{ steps.update.outputs.did-update }}
+    value: ${{ steps.update.outputs.updated-count != '0' }}
   pr-number:
     description: The number of the created Pull Request.
     value: ${{ steps.create-pr.outputs.pull-request-number }}


### PR DESCRIPTION
Relates to #62, #68, #118

## Summary

Derive `did-output` from `updated-count` instead of computing it.