### PR TITLE
Define script output names once

### DIFF
--- a/bin/update.sh
+++ b/bin/update.sh
@@ -12,6 +12,9 @@ max_capacity=${MAX}
 remaining_capacity=${MAX}
 updated_count=0
 
+output_name_did_update='did-update'
+output_name_updated_count='updated-count'
+
 # --- Import ----------------------------------------------------------------- #
 
 # shellcheck source=./lib/actions.sh
@@ -20,8 +23,8 @@ source "${bin_dir}/../lib/actions.sh"
 # --- Script ----------------------------------------------------------------- #
 
 debug "initializing outputs to their default value"
-set_output 'did-update' 'false'
-set_output 'updated-count' "${updated_count}"
+set_output "${output_name_did_update}" 'false'
+set_output "${output_name_updated_count}" "${updated_count}"
 
 debug "checking if .tool-versions file exists"
 if [[ ! -f '.tool-versions' ]]; then
@@ -72,12 +75,12 @@ while read -r line; do
 			debug "applying ${tool}@${latest_version} locally"
 			asdf local "${tool}" "${latest_version}"
 
-			debug "overriding 'did-update' output to true"
-			set_output 'did-update' 'true'
+			debug "overriding '${output_name_did_update}' output to true"
+			set_output "${output_name_did_update}" 'true'
 
-			debug "overriding 'updated-count' output with new value"
+			debug "overriding '${output_name_updated_count}' output with new value"
 			((updated_count += 1))
-			set_output 'updated-count' "${updated_count}"
+			set_output "${output_name_updated_count}" "${updated_count}"
 
 			remaining_capacity=$((remaining_capacity - 1))
 			debug "remaining update capacity: ${remaining_capacity}"


### PR DESCRIPTION
## Summary

To avoid errors due to repetition of the output names in the `update.sh` script, define the names once and use a variable in their place when setting the output value.