### PR TITLE
Add `skip` input

### DIFF
--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -27,5 +27,6 @@ jobs:
         with:
           labels: dependencies
           max: 2
-          not: act
+          skip: |
+            act 0.2.52
           token: ${{ steps.automation-token.outputs.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,15 @@ Versioning].
 
 ### `tool-versions-update-action`
 
-- _No changes yet._
+- Add input `skip` to configure versions of tools to skip when updating.
 
 ### `tool-versions-update-action/commit`
 
-- _No changes yet._
+- Add input `skip` to configure versions of tools to skip when updating.
 
 ### `tool-versions-update-action/pr`
 
-- _No changes yet._
+- Add input `skip` to configure versions of tools to skip when updating.
 
 ## [0.3.7] - 2023-10-29
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ The first stable release (if reached) will be v1.0.0.
     #
     # Default: ""
     only: shellcheck
+
+    # A newline-separated list of "tool version" pairs that should NOT be
+    # updated to.
+    #
+    # Default: ""
+    skip: |
+      shfmt 3.6.0
+      yamllint 1.31.0
 ```
 
 ### Batteries Included

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,12 @@ inputs:
       A comma-separated list of tools that should be updated, ignoring others.
     required: false
     default: ""
+  skip:
+    description: |
+      A newline-separated list of "tool version" pairs that should NOT be
+      updated to.
+    required: false
+    default: ""
 
 outputs:
   did-update:
@@ -40,3 +46,4 @@ runs:
         MAX: ${{ inputs.max }}
         NOT: ${{ inputs.not }}
         ONLY: ${{ inputs.only }}
+        SKIP: ${{ inputs.skip }}

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -10,6 +10,7 @@ exclusions=${NOT}
 inclusions=${ONLY}
 max_capacity=${MAX}
 remaining_capacity=${MAX}
+skips=${SKIP}
 updated_count=0
 
 output_name_updated_count='updated-count'
@@ -66,7 +67,30 @@ while read -r line; do
 		debug "${tool} current: ${current_version}, latest: ${latest_version}"
 
 		if [ "${current_version}" != "${latest_version}" ]; then
-			info "update available for ${tool}, applying update..."
+			info "update available for ${tool}"
+
+			if [[ -n ${skips} ]]; then
+				debug "checking if ${tool}@${latest_version} should be skipped..."
+				while read -r line; do
+					case "${line}" in
+					"")
+						debug "skipping empty line"
+						;;
+					*)
+						debug "processing skip line ('${line}')"
+
+						name="$(echo "${line}" | awk '{print $1}')"
+						version="$(echo "${line}" | awk '{print $2}')"
+						debug "found skip mandate for ${name}@${version}"
+
+						if [ "${name}" == "${tool}" ] && [ "${version}" == "${latest_version}" ]; then
+							info "skipping ${name}@${version} because it is configured in the skip rule"
+							continue 2
+						fi
+						;;
+					esac
+				done <<<"${skips}"
+			fi
 
 			debug "installing ${tool}@${latest_version}"
 			asdf install "${tool}" "${latest_version}"

--- a/commit/README.md
+++ b/commit/README.md
@@ -43,6 +43,14 @@ file through a commit.
       actionlint https://github.com/crazy-matt/asdf-actionlint
       shellcheck https://github.com/luizm/asdf-shellcheck
 
+    # A newline-separated list of "tool version" pairs that should NOT be
+    # updated to.
+    #
+    # Default: ""
+    skip: |
+      shfmt 3.6.0
+      yamllint 1.31.0
+
     # The $GITHUB_TOKEN or a repository scoped Personal Access Token (PAT).
     #
     # Default: $GITHUB_TOKEN

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -36,6 +36,12 @@ inputs:
       If omitted the default plugins will be available.
     required: false
     default: ""
+  skip:
+    description: |
+      A newline-separated list of "tool version" pairs that should NOT be
+      updated to.
+    required: false
+    default: ""
   token:
     description: |
       The $GITHUB_TOKEN or a repository scoped Personal Access Token (PAT).
@@ -83,6 +89,7 @@ runs:
         MAX: ${{ inputs.max }}
         NOT: ${{ inputs.not }}
         ONLY: ${{ inputs.only }}
+        SKIP: ${{ inputs.skip }}
 
     - name: Create commit
       id: create-commit

--- a/pr/README.md
+++ b/pr/README.md
@@ -76,6 +76,14 @@ file through a Pull Request.
     # Default: ""
     reviewers: ericcornelissen
 
+    # A newline-separated list of "tool version" pairs that should NOT be
+    # updated to.
+    #
+    # Default: ""
+    skip: |
+      shfmt 3.6.0
+      yamllint 1.31.0
+
     # The $GITHUB_TOKEN or a repository scoped Personal Access Token (PAT).
     #
     # Default: $GITHUB_TOKEN

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -68,6 +68,12 @@ inputs:
       GitHub username).
     required: false
     default: ""
+  skip:
+    description: |
+      A newline-separated list of "tool version" pairs that should NOT be
+      updated to.
+    required: false
+    default: ""
   token:
     description: |
       The $GITHUB_TOKEN or a repository scoped Personal Access Token (PAT).
@@ -115,6 +121,7 @@ runs:
         MAX: ${{ inputs.max }}
         NOT: ${{ inputs.not }}
         ONLY: ${{ inputs.only }}
+        SKIP: ${{ inputs.skip }}
 
     - name: Create Pull Request
       id: create-pr


### PR DESCRIPTION
Closes #24

## Summary

Add an input option which allows users to define a list of "tool version" where if there is a line `$tool $version` such that `$version` matched the latest available version for `$tool`, then the update won't be applied for that `$tool`. This option is available in all variants of the action.