### PR TITLE
Replace `Dockerfile` with `Containerfile`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,7 +20,7 @@ indent_style=tab
 indent_size=2
 indent_style=space
 
-[Dockerfile]
+[Containerfile]
 indent_size=4
 indent_style=tab
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,14 +2,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: docker
-    directory: /
-    open-pull-requests-limit: 1
-    schedule:
-      interval: daily
-      time: "04:00"
-    labels:
-      - dependencies
   - package-ecosystem: github-actions
     directory: /
     open-pull-requests-limit: 1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install tooling
         uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3.0.2
       - name: Lint
-        run: make lint-docker
+        run: make lint-container
       - name: Build
         run: make dev-img
   shell:

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 !/.version
 
 ## Build tooling
-!/Dockerfile
+!/Containerfile
 !/Makefile
 
 ## Configuration

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,5 @@
 # Check out Docker at: https://www.docker.com/
+# Check out Podman at: https://podman.io/
 
 # NOTE: THIS IMAGE IS INTENDED FOR DEVELOPMENT PURPOSES ONLY
 
@@ -7,14 +8,14 @@ FROM alpine:3.18.4
 RUN apk add --no-cache \
 	bash curl git jq make python3 py3-pip
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ENV ASDF_DIR="/.asdf"
 
 WORKDIR /setup
 COPY .tool-versions .
 
-RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.13.1 \
-	&& echo '. "$HOME/.asdf/asdf.sh"' > ~/.bashrc \
-	&& . "$HOME/.asdf/asdf.sh" \
+RUN git clone https://github.com/asdf-vm/asdf.git /.asdf --branch v0.13.1 \
+	&& echo '. "/.asdf/asdf.sh"' > ~/.bashrc \
+	&& . '/.asdf/asdf.sh' \
 	&& asdf plugin add act \
 	&& asdf plugin add actionlint \
 	&& asdf plugin add hadolint \

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+CONTAINER_ENGINE?=docker
+
 SHELL_SCRIPTS:=./bin/*.sh ./lib/*.sh
 SPEC_SCRIPTS:=./spec/*.sh ./spec/**/*.sh
 
@@ -26,8 +28,8 @@ clean: ## Clean the repository
 		$(TMP_DIR)
 
 .PHONY: dev-env dev-img
-dev-env: dev-img ## Run an ephemeral development environment with Docker
-	@docker run \
+dev-env: dev-img ## Run an ephemeral development environment container
+	@$(CONTAINER_ENGINE) run \
 		-it \
 		--rm \
 		--workdir "/tool-versions-update-action" \
@@ -35,7 +37,7 @@ dev-env: dev-img ## Run an ephemeral development environment with Docker
 		--name "$(DEV_ENV_NAME)" \
 		"$(DEV_IMG_NAME)"
 
-dev-img: $(DEV_IMG) ## Build a development environment image with Docker
+dev-img: $(DEV_IMG) ## Build a development environment container image
 
 .PHONY: format format-check
 format: $(ASDF) ## Format the source code
@@ -52,14 +54,14 @@ help: ## Show this help message
 		printf "  \033[36m%-30s\033[0m %s\n", $$1, $$NF \
 	}' $(MAKEFILE_LIST)
 
-.PHONY: lint lint-ci lint-docker lint-sh lint-yml
-lint: lint-ci lint-docker lint-sh lint-yml ## Run lint-*
+.PHONY: lint lint-ci lint-container lint-sh lint-yml
+lint: lint-ci lint-container lint-sh lint-yml ## Run lint-*
 
 lint-ci: $(ASDF) ## Lint CI workflow files
 	@actionlint
 
-lint-docker: $(ASDF) ## Lint the Dockerfile
-	@hadolint Dockerfile
+lint-container: $(ASDF) ## Lint the Containerfile
+	@hadolint Containerfile
 
 lint-sh: $(ASDF) ## Lint shell scripts
 	@shellcheck $(SHELL_SCRIPTS) $(SPEC_SCRIPTS)
@@ -76,7 +78,7 @@ test-e2e: ## Run end-to-end tests
 
 .PHONY: update-actions
 update-actions: ## Update (and pin) all actions used by these actions
-	@docker run \
+	@$(CONTAINER_ENGINE) run \
 		--rm \
 		--workdir "/tool-versions-update-action" \
 		--mount "type=bind,source=$(shell pwd),target=/tool-versions-update-action" \
@@ -104,6 +106,6 @@ $(ASDF): .tool-versions | $(TMP_DIR)
 	@asdf install
 	@touch $(ASDF)
 
-$(DEV_IMG): .tool-versions Dockerfile | $(TMP_DIR)
-	@docker build --tag $(DEV_IMG_NAME) .
+$(DEV_IMG): .tool-versions Containerfile | $(TMP_DIR)
+	@$(CONTAINER_ENGINE) build --file Containerfile --tag $(DEV_IMG_NAME) .
 	@touch $(DEV_IMG)


### PR DESCRIPTION
## Summary

Move to a `Containerfile` based ephemeral development environment container image in order to be vendor agnostic. Nothing much should be changed except that it has become easier to use a different container engine when working on this project.
