### PR TITLE
Set up test coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,5 +28,12 @@ jobs:
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - name: Install tooling
         uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3.0.2
+      - name: Install kcov
+        run: sudo apt-get install kcov
       - name: Run unit tests
-        run: make test
+        run: make coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+        if: ${{ always() }}
+        with:
+          file: ./_coverage/tool-versions-update-action [specfiles]/cobertura.xml

--- a/.shellspec
+++ b/.shellspec
@@ -1,8 +1,13 @@
 # Check out ShellSpec at: https://shellspec.info/
 
---covdir _coverage/
 --format documentation
 --reportdir _reports/
 --require spec_helper
 --shell bash
 --show-deprecations
+
+## kcov (coverage)
+--covdir _coverage/
+--kcov-options "--exclude-pattern=/_coverage/,/_report/,/spec/,/.shellcheckrc,/.shellspec"
+--kcov-options "--include-path=. --path-strip-level=1"
+--kcov-options "--include-pattern=.sh"

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ clean: ## Clean the repository
 		$(REPORT_DIR) \
 		$(TMP_DIR)
 
+.PHONY: coverage
+coverage: $(ASDF) | $(TMP_DIR) ## Run tests with coverage
+	@shellspec --kcov
+
 .PHONY: dev-env dev-img
 dev-env: dev-img ## Run an ephemeral development environment container
 	@$(CONTAINER_ENGINE) run \
@@ -70,7 +74,7 @@ lint-yml: $(ASDF) ## Lint YAML files
 	@yamllint -c .yamllint.yml .
 
 .PHONY: test test-e2e
-test: | $(TMP_DIR) ## Run tests
+test: $(ASDF) | $(TMP_DIR) ## Run tests
 	@shellspec
 
 test-e2e: ## Run end-to-end tests


### PR DESCRIPTION
Relates to #128

## Summary

Extend the unit test setup with code coverage powered by [kcov] as supported by [ShellSpec]. Coverage is configured in the `.shellspec` file and can be invoked with the `make coverage` command. The continuous integration now also runs tests with coverage, and uploads the results to [Codecov](https://codecov.io/).

[kcov]: https://github.com/SimonKagstrom/kcov
[ShellSpec]: https://github.com/shellspec/shellspec