### PR TITLE
Add input `signoff` to `/pr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Versioning].
 
 ### `tool-versions-update-action/pr`
 
+- Add input `signoff` to add "Signed-off-by" line at the end of the commit
+  message.
 - Add output `updated-tools`.
 - Improve debug logs with fewer repetitions.
 

--- a/pr/README.md
+++ b/pr/README.md
@@ -76,6 +76,12 @@ file through a Pull Request.
     # Default: ""
     reviewers: ericcornelissen
 
+    # Add "Signed-off-by" line at the end of the commit message. See `--signoff`
+    # in <https://git-scm.com/docs/git-commit> for more detail.
+    #
+    # Default: false
+    signoff: true
+
     # A newline-separated list of "tool version" pairs that should NOT be
     # updated to.
     #

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -68,6 +68,12 @@ inputs:
       GitHub username).
     required: false
     default: ""
+  signoff:
+    description: |
+      Add "Signed-off-by" line at the end of the commit message. See `--signoff`
+      in <https://git-scm.com/docs/git-commit> for more detail.
+    required: false
+    default: false
   skip:
     description: |
       A newline-separated list of "tool version" pairs that should NOT be
@@ -146,3 +152,4 @@ runs:
         # Commit
         commit-message: ${{ inputs.commit-message }}
         add-paths: .tool-versions
+        signoff: ${{ inputs.signoff }}


### PR DESCRIPTION
Relates to #143

## Summary

Add input `signoff` to effectively enable [`--signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) for the `/pr` version of the Action.