### PR TITLE
Run tests on multiple runner images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,6 @@ jobs:
         run: make coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
-        if: ${{ always() }}
+        if: ${{ matrix.runs-on == 'ubuntu-22.04' }}
         with:
           file: ./_coverage/tool-versions-update-action [specfiles]/cobertura.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,14 @@ jobs:
       - name: Run bare action
         uses: ./
   unit:
-    name: Unit
-    runs-on: ubuntu-22.04
+    name: Unit (${{ matrix.runs-on }})
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on:
+          - ubuntu-20.04
+          - ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ jobs:
         run: git diff .tool-versions
 ```
 
+### Runners
+
+This action is tested on the official [`ubuntu-20.04`] and [`ubuntu-22.04`]
+runner images. It is recommended to use one of these images when using this
+action.
+
 ### Security
 
 #### Permissions
@@ -121,3 +127,5 @@ license text. The contents of documentation is licensed under [CC BY 4.0].
 [github actions]: https://github.com/features/actions
 [github actions output docs]: https://help.github.com/en/actions/reference/contexts-and-expression-syntax-for-github-actions#steps-context
 [license]: ./LICENSE
+[`ubuntu-20.04`]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md
+[`ubuntu-22.04`]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md

--- a/commit/README.md
+++ b/commit/README.md
@@ -95,6 +95,12 @@ jobs:
           max: 2
 ```
 
+### Runners
+
+This action is tested on the official [`ubuntu-20.04`] and [`ubuntu-22.04`]
+runner images. It is recommended to use one of these images when using this
+action.
+
 ### Security
 
 #### Permissions
@@ -125,3 +131,5 @@ The contents of this document are licensed under [CC BY 4.0].
 [cc by 4.0]: https://creativecommons.org/licenses/by/4.0/
 [github action]: https://github.com/features/actions
 [github actions output docs]: https://help.github.com/en/actions/reference/contexts-and-expression-syntax-for-github-actions#steps-context
+[`ubuntu-20.04`]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md
+[`ubuntu-22.04`]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md

--- a/pr/README.md
+++ b/pr/README.md
@@ -136,6 +136,12 @@ jobs:
           max: 2
 ```
 
+### Runners
+
+This action is tested on the official [`ubuntu-20.04`] and [`ubuntu-22.04`]
+runner images. It is recommended to use one of these images when using this
+action.
+
 ### Security
 
 #### Permissions
@@ -167,3 +173,5 @@ The contents of this document are licensed under [CC BY 4.0].
 [cc by 4.0]: https://creativecommons.org/licenses/by/4.0/
 [github action]: https://github.com/features/actions
 [github actions output docs]: https://help.github.com/en/actions/reference/contexts-and-expression-syntax-for-github-actions#steps-context
+[`ubuntu-20.04`]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md
+[`ubuntu-22.04`]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md


### PR DESCRIPTION
Relates to #70, #128

## Summary

Update the Test CI workflow to run unit tests on all currently available Linux runner images to ensure the Actions would work on each of them. Correspondingly, add sections to the various action docs that these runner images are tested and recommended.