### PR TITLE
Add input `signoff` to `/commit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ Versioning].
 
 ### `tool-versions-update-action/commit`
 
-- _No changes yet._
+- Add input `signoff` to add "Signed-off-by" line at the end of the commit
+  message.
 
 ### `tool-versions-update-action/pr`
 

--- a/commit/README.md
+++ b/commit/README.md
@@ -43,6 +43,12 @@ file through a commit.
       actionlint https://github.com/crazy-matt/asdf-actionlint
       shellcheck https://github.com/luizm/asdf-shellcheck
 
+    # Add "Signed-off-by" line at the end of the commit message. See `--signoff`
+    # in <https://git-scm.com/docs/git-commit> for more detail.
+    #
+    # Default: false
+    signoff: true
+
     # A newline-separated list of "tool version" pairs that should NOT be
     # updated to.
     #

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -36,6 +36,12 @@ inputs:
       If omitted the default plugins will be available.
     required: false
     default: ""
+  signoff:
+    description: |
+      Add "Signed-off-by" line at the end of the commit message. See `--signoff`
+      in <https://git-scm.com/docs/git-commit> for more detail.
+    required: false
+    default: false
   skip:
     description: |
       A newline-separated list of "tool version" pairs that should NOT be
@@ -94,6 +100,15 @@ runs:
         ONLY: ${{ inputs.only }}
         SKIP: ${{ inputs.skip }}
 
+    - name: Commit options
+      id: commit-options
+      shell: bash
+      run: |
+        if [[ "${SIGNOFF}" == "true" ]]; then
+          echo "value=--signoff" >>"${GITHUB_OUTPUT}"
+        fi
+      env:
+        SIGNOFF: ${{ inputs.signoff || true }}
     - name: Create commit
       id: create-commit
       uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d # pin@v5
@@ -105,4 +120,5 @@ runs:
 
         # Commit
         commit_message: ${{ inputs.commit-message }}
+        commit_options: ${{ steps.commit-options.outputs.value }}
         file_pattern: .tool-versions

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -108,7 +108,7 @@ runs:
           echo "value=--signoff" >>"${GITHUB_OUTPUT}"
         fi
       env:
-        SIGNOFF: ${{ inputs.signoff || true }}
+        SIGNOFF: ${{ true && inputs.signoff }}
     - name: Create commit
       id: create-commit
       uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d # pin@v5

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -108,7 +108,7 @@ runs:
           echo "value=--signoff" >>"${GITHUB_OUTPUT}"
         fi
       env:
-        SIGNOFF: ${{ true && inputs.signoff }}
+        SIGNOFF: ${{ inputs.signoff && true }}
     - name: Create commit
       id: create-commit
       uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d # pin@v5

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -104,11 +104,11 @@ runs:
       id: commit-options
       shell: bash
       run: |
-        if [[ "${SIGNOFF}" == "true" ]]; then
+        if [[ "${SIGNOFF}" == 'true' ]]; then
           echo "value=--signoff" >>"${GITHUB_OUTPUT}"
         fi
       env:
-        SIGNOFF: ${{ inputs.signoff && true }}
+        SIGNOFF: ${{ inputs.signoff }}
     - name: Create commit
       id: create-commit
       uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d # pin@v5


### PR DESCRIPTION
Relates to #143, #145

## Summary

Add input `signoff` to effectively enable [`--signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) for the `/commit` version of the Action.