### PR TITLE
Add output templating support to some inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,15 @@ Versioning].
 
 - Add input `signoff` to add "Signed-off-by" line at the end of the commit
   message.
+- Add support for templating `updated-count` and `updated-tools` into the input
+  `commit-message`.
+- Update default `commit-message`.
 
 ### `tool-versions-update-action/pr`
 
-- _No changes yet._
+- Add support for templating `updated-count` and `updated-tools` into the inputs
+  `commit-message`, `pr-body`, and `pr-title`.
+- Update default `commit-message`, `pr-body`, and `pr-title`.
 
 ## [0.3.9] - 2023-11-19
 

--- a/bin/templating.sh
+++ b/bin/templating.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+# --- Setup ------------------------------------------------------------------ #
+
+set -eo pipefail
+
+bin_dir=$(dirname "${BASH_SOURCE[0]}")
+value=${TEMPLATE}
+
+# --- Import ----------------------------------------------------------------- #
+
+# shellcheck source=./lib/actions.sh
+source "${bin_dir}/../lib/actions.sh"
+
+# --- Script ----------------------------------------------------------------- #
+
+group_start "Templating..."
+
+debug "input '${value}'"
+
+debug "substitute '{{updated-count}}' for '${UPDATED_COUNT}'"
+value=${value//'{{updated-count}}'/"${UPDATED_COUNT}"}
+
+debug "substitute '{{updated-tools}}' for '${UPDATED_TOOLS}'"
+value=${value//'{{updated-tools}}'/"${UPDATED_TOOLS}"}
+
+debug "setting output"
+set_output 'value' "${value}"
+
+group_end

--- a/bin/templating.sh
+++ b/bin/templating.sh
@@ -15,9 +15,7 @@ source "${bin_dir}/../lib/actions.sh"
 
 # --- Script ----------------------------------------------------------------- #
 
-group_start "Templating..."
-
-debug "input '${value}'"
+debug "input for templating is '${value}'"
 
 debug "substitute '{{updated-count}}' for '${UPDATED_COUNT}'"
 value=${value//'{{updated-count}}'/"${UPDATED_COUNT}"}
@@ -27,5 +25,3 @@ value=${value//'{{updated-tools}}'/"${UPDATED_TOOLS}"}
 
 debug "setting output"
 set_output 'value' "${value}"
-
-group_end

--- a/commit/README.md
+++ b/commit/README.md
@@ -17,8 +17,11 @@ file through a commit.
 
     # The message to use for commits.
     #
-    # Default: "Update .tool-versions"
-    commit-message: Update tooling
+    # This input supports templating, see the "Templating" section for more
+    # information.
+    #
+    # Default: "Update {{updated-tools}}"
+    commit-message: Update {{updated-count}} tool(s) ({{updated-tools}})
 
     # The maximum number of tools to update. 0 indicates no maximum.
     #
@@ -75,6 +78,25 @@ The following outputs are made available:
 | `updated-tools` | A comma separated list of the names of the updated tools   |
 
 For information on how to use outputs see the [GitHub Actions output docs].
+
+#### Templating
+
+Some inputs support a simple templating language to embed outputs before use. To
+use a template variable use the string `{{output-name}}` in the input value, for
+example:
+
+```text
+This template string uses the {{update-count}} output
+```
+
+The following inputs support templating:
+
+- `commit-message`
+
+The following outputs are available for templating:
+
+- `updated-count`
+- `updated-tools`
 
 ### Full Example
 

--- a/commit/README.md
+++ b/commit/README.md
@@ -86,7 +86,13 @@ use a template variable use the string `{{output-name}}` in the input value, for
 example:
 
 ```text
-This template string uses the {{update-count}} output
+This template string uses the '{{updated-count}}' output
+```
+
+could become:
+
+```text
+This template string uses the '3' output
 ```
 
 The following inputs support templating:

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: |
       The message to use for commits.
     required: false
-    default: Update .tool-versions
+    default: Update {{updated-tools}}
   max:
     description: |
       The maximum number of tools to update. 0 indicates no maximum.
@@ -100,6 +100,14 @@ runs:
         ONLY: ${{ inputs.only }}
         SKIP: ${{ inputs.skip }}
 
+    - name: Commit message
+      id: commit-message
+      shell: bash
+      run: $GITHUB_ACTION_PATH/../bin/templating.sh
+      env:
+        TEMPLATE: ${{ inputs.commit-message }}
+        UPDATED_COUNT: ${{ steps.update.outputs.updated-count }}
+        UPDATED_TOOLS: ${{ steps.update.outputs.updated-tools }}
     - name: Commit options
       id: commit-options
       shell: bash
@@ -109,6 +117,7 @@ runs:
         fi
       env:
         SIGNOFF: ${{ inputs.signoff }}
+
     - name: Create commit
       id: create-commit
       uses: stefanzweifel/git-auto-commit-action@8756aa072ef5b4a080af5dc8fef36c5d586e521d # pin@v5
@@ -119,6 +128,6 @@ runs:
         branch: ${{ inputs.branch }}
 
         # Commit
-        commit_message: ${{ inputs.commit-message }}
+        commit_message: ${{ steps.commit-message.outputs.value }}
         commit_options: ${{ steps.commit-options.outputs.value }}
         file_pattern: .tool-versions

--- a/pr/README.md
+++ b/pr/README.md
@@ -23,8 +23,11 @@ file through a Pull Request.
 
     # The message to use for commits.
     #
-    # Default: "Update .tool-versions"
-    commit-message: Update tooling
+    # This input supports templating, see the "Templating" section for more
+    # information.
+    #
+    # Default: "Update {{updated-tools}}"
+    commit-message: Update {{updated-count}} tool(s) ({{updated-tools}})
 
     # A comma or newline-separated list of labels for Pull Requests.
     #
@@ -61,13 +64,23 @@ file through a Pull Request.
 
     # The body text to use for Pull Requests.
     #
-    # Default: "Bump tools in `.tool-versions`"
+    # This input supports templating, see the "Templating" section for more
+    # information.
+    #
+    # Default: "Update {{updated-count}} tool(s) ({{updated-tools}})"
     pr-body: |
+      Update {{updated-count}} tool(s): {{updated-tools}}
+
+      ---
+
       _This Pull Request was generated using the `tool-versions-update-action`_
 
     # The title to use for Pull Requests.
     #
-    # Default: "Update `.tool-versions`"
+    # This input supports templating, see the "Templating" section for more
+    # information.
+    #
+    # Default: "Update {{updated-count}} tool(s)"
     pr-title: Update tooling
 
     # A comma or newline-separated list of reviewers for Pull Requests (by their
@@ -109,6 +122,27 @@ The following outputs are made available:
 | `updated-tools` | A comma separated list of the names of the updated tools   |
 
 For information on how to use outputs see the [GitHub Actions output docs].
+
+#### Templating
+
+Some inputs support a simple templating language to embed outputs before use. To
+use a template variable use the string `{{output-name}}` in the input value, for
+example:
+
+```text
+This template string uses the {{update-count}} output
+```
+
+The following inputs support templating:
+
+- `commit-message`
+- `pr-body`
+- `pr-title`
+
+The following outputs are available for templating:
+
+- `updated-count`
+- `updated-tools`
 
 ### Full Example
 

--- a/pr/README.md
+++ b/pr/README.md
@@ -130,7 +130,13 @@ use a template variable use the string `{{output-name}}` in the input value, for
 example:
 
 ```text
-This template string uses the {{update-count}} output
+This template string uses the '{{updated-count}}' output
+```
+
+could become:
+
+```text
+This template string uses the '3' output
 ```
 
 The following inputs support templating:

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: |
       The message to use for commits.
     required: false
-    default: Update .tool-versions
+    default: Update {{updated-tools}}
   labels:
     description: |
       A comma or newline-separated list of labels for Pull Requests.
@@ -56,12 +56,12 @@ inputs:
     description: |
       The body text to use for Pull Requests.
     required: false
-    default: Bump tools in `.tool-versions`
+    default: Update {{updated-count}} tool(s) ({{updated-tools}})
   pr-title:
     description: |
       The title to use for Pull Requests.
     required: false
-    default: Update `.tool-versions`
+    default: Update {{updated-count}} tool(s)
   reviewers:
     description: |
       A comma or newline-separated list of reviewers for Pull Requests (by their
@@ -132,6 +132,31 @@ runs:
         ONLY: ${{ inputs.only }}
         SKIP: ${{ inputs.skip }}
 
+    - name: Pull Request title
+      id: pr-title
+      shell: bash
+      run: $GITHUB_ACTION_PATH/../bin/templating.sh
+      env:
+        TEMPLATE: ${{ inputs.pr-title }}
+        UPDATED_COUNT: ${{ steps.update.outputs.updated-count }}
+        UPDATED_TOOLS: ${{ steps.update.outputs.updated-tools }}
+    - name: Pull Request body
+      id: pr-body
+      shell: bash
+      run: $GITHUB_ACTION_PATH/../bin/templating.sh
+      env:
+        TEMPLATE: ${{ inputs.pr-body }}
+        UPDATED_COUNT: ${{ steps.update.outputs.updated-count }}
+        UPDATED_TOOLS: ${{ steps.update.outputs.updated-tools }}
+    - name: Commit message
+      id: commit-message
+      shell: bash
+      run: $GITHUB_ACTION_PATH/../bin/templating.sh
+      env:
+        TEMPLATE: ${{ inputs.commit-message }}
+        UPDATED_COUNT: ${{ steps.update.outputs.updated-count }}
+        UPDATED_TOOLS: ${{ steps.update.outputs.updated-tools }}
+
     - name: Create Pull Request
       id: create-pr
       uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # pin@v5
@@ -139,8 +164,8 @@ runs:
         token: ${{ inputs.token }}
 
         # Pull Request
-        title: ${{ inputs.pr-title }}
-        body: ${{ inputs.pr-body }}
+        title: ${{ steps.pr-title.outputs.value }}
+        body: ${{ steps.pr-body.outputs.value }}
         base: ${{ inputs.pr-base }}
         reviewers: ${{ inputs.reviewers }}
         assignees: ${{ inputs.assignees }}
@@ -150,6 +175,6 @@ runs:
         branch: ${{ inputs.branch }}
 
         # Commit
-        commit-message: ${{ inputs.commit-message }}
+        commit-message: ${{ steps.commit-message.outputs.value }}
         add-paths: .tool-versions
         signoff: ${{ inputs.signoff }}

--- a/spec/bin/templating_spec.sh
+++ b/spec/bin/templating_spec.sh
@@ -1,0 +1,72 @@
+# shellcheck shell=bash disable=SC2155,SC2317
+# SPDX-License-Identifier: MIT
+
+BeforeEach 'clear_github_output'
+
+Describe 'bin/install-plugins.sh'
+	setup() {
+		export UPDATED_COUNT=2
+		export UPDATED_TOOLS='shellcheck,shellspec'
+		export TEMPLATE="$(input)"
+	}
+
+	BeforeEach 'setup'
+
+	Describe '{{updated-count}}'
+		input() {
+			%text
+			#|Update {{updated-count}} tool(s)
+		}
+
+		snapshot_stdout() {
+			%text
+			#|::group::Templating...
+			#|::debug::input 'Update {{updated-count}} tool(s)'
+			#|::debug::substitute '{{updated-count}}' for '2'
+			#|::debug::substitute '{{updated-tools}}' for 'shellcheck,shellspec'
+			#|::debug::setting output
+			#|::endgroup::
+		}
+
+		snapshot_outputs() {
+			%text
+			#|value=Update 2 tool(s)
+		}
+
+		It 'works for a simple example'
+			When run script bin/templating.sh
+			The status should equal 0
+			The output should equal "$(snapshot_stdout)"
+			The file "${GITHUB_OUTPUT}" should satisfy contents "$(snapshot_outputs)"
+		End
+	End
+
+	Describe '{{updated-tools}}'
+		input() {
+			%text
+			#|Update tool(s) {{updated-tools}}
+		}
+
+		snapshot_stdout() {
+			%text
+			#|::group::Templating...
+			#|::debug::input 'Update tool(s) {{updated-tools}}'
+			#|::debug::substitute '{{updated-count}}' for '2'
+			#|::debug::substitute '{{updated-tools}}' for 'shellcheck,shellspec'
+			#|::debug::setting output
+			#|::endgroup::
+		}
+
+		snapshot_outputs() {
+			%text
+			#|value=Update tool(s) shellcheck,shellspec
+		}
+
+		It 'works for a simple example'
+			When run script bin/templating.sh
+			The status should equal 0
+			The output should equal "$(snapshot_stdout)"
+			The file "${GITHUB_OUTPUT}" should satisfy contents "$(snapshot_outputs)"
+		End
+	End
+End

--- a/spec/bin/templating_spec.sh
+++ b/spec/bin/templating_spec.sh
@@ -3,7 +3,7 @@
 
 BeforeEach 'clear_github_output'
 
-Describe 'bin/install-plugins.sh'
+Describe 'bin/templating.sh'
 	setup() {
 		export UPDATED_COUNT=2
 		export UPDATED_TOOLS='shellcheck,shellspec'
@@ -20,15 +20,13 @@ Describe 'bin/install-plugins.sh'
 
 		snapshot_stdout() {
 			%text
-			#|::group::Templating...
-			#|::debug::input 'Update {{updated-count}} tool(s)'
+			#|::debug::input for templating is 'Update {{updated-count}} tool(s)'
 			#|::debug::substitute '{{updated-count}}' for '2'
 			#|::debug::substitute '{{updated-tools}}' for 'shellcheck,shellspec'
 			#|::debug::setting output
-			#|::endgroup::
 		}
 
-		snapshot_outputs() {
+		snapshot_output() {
 			%text
 			#|value=Update 2 tool(s)
 		}
@@ -37,7 +35,7 @@ Describe 'bin/install-plugins.sh'
 			When run script bin/templating.sh
 			The status should equal 0
 			The output should equal "$(snapshot_stdout)"
-			The file "${GITHUB_OUTPUT}" should satisfy contents "$(snapshot_outputs)"
+			The file "${GITHUB_OUTPUT}" should satisfy contents "$(snapshot_output)"
 		End
 	End
 
@@ -49,15 +47,13 @@ Describe 'bin/install-plugins.sh'
 
 		snapshot_stdout() {
 			%text
-			#|::group::Templating...
-			#|::debug::input 'Update tool(s) {{updated-tools}}'
+			#|::debug::input for templating is 'Update tool(s) {{updated-tools}}'
 			#|::debug::substitute '{{updated-count}}' for '2'
 			#|::debug::substitute '{{updated-tools}}' for 'shellcheck,shellspec'
 			#|::debug::setting output
-			#|::endgroup::
 		}
 
-		snapshot_outputs() {
+		snapshot_output() {
 			%text
 			#|value=Update tool(s) shellcheck,shellspec
 		}
@@ -66,7 +62,7 @@ Describe 'bin/install-plugins.sh'
 			When run script bin/templating.sh
 			The status should equal 0
 			The output should equal "$(snapshot_stdout)"
-			The file "${GITHUB_OUTPUT}" should satisfy contents "$(snapshot_outputs)"
+			The file "${GITHUB_OUTPUT}" should satisfy contents "$(snapshot_output)"
 		End
 	End
 End


### PR DESCRIPTION
Closes #150

## Summary

Add support for templating to `/commit` (inputs: `commit-message`) and `/pr` (inputs: `commit-message`, `pr-body`, `pr-title`) in order to allow using the output values `updated-count` and `update-tools` there. Also utilize this feature in the default values for these inputs.