### PR TITLE
Refactor scripts for clarity and consistency

### DIFF
--- a/bin/install-plugins.sh
+++ b/bin/install-plugins.sh
@@ -5,8 +5,11 @@
 
 set -o pipefail
 
-exit_code=0
+## Inputs
 plugin_list=${LIST}
+
+## State
+exit_code=0
 
 # --- Import ----------------------------------------------------------------- #
 

--- a/bin/install-plugins.sh
+++ b/bin/install-plugins.sh
@@ -5,14 +5,15 @@
 
 set -o pipefail
 
-bin_dir=$(dirname "${BASH_SOURCE[0]}")
 exit_code=0
 plugin_list=${LIST}
 
 # --- Import ----------------------------------------------------------------- #
 
+bin=$(dirname "${BASH_SOURCE[0]}")
+
 # shellcheck source=./lib/actions.sh
-source "${bin_dir}/../lib/actions.sh"
+source "${bin}/../lib/actions.sh"
 
 # --- Script ----------------------------------------------------------------- #
 

--- a/bin/templating.sh
+++ b/bin/templating.sh
@@ -8,6 +8,9 @@ set -eo pipefail
 ## Inputs
 template=${TEXT}
 
+## Constants
+output_name_value="value"
+
 ## State
 value=${template}
 
@@ -29,4 +32,4 @@ debug "substitute '{{updated-tools}}' for '${UPDATED_TOOLS}'"
 value=${value//'{{updated-tools}}'/"${UPDATED_TOOLS}"}
 
 debug "setting output"
-set_output "value" "${value}"
+set_output "${output_name_value}" "${value}"

--- a/bin/templating.sh
+++ b/bin/templating.sh
@@ -25,4 +25,4 @@ debug "substitute '{{updated-tools}}' for '${UPDATED_TOOLS}'"
 value=${value//'{{updated-tools}}'/"${UPDATED_TOOLS}"}
 
 debug "setting output"
-set_output 'value' "${value}"
+set_output "value" "${value}"

--- a/bin/templating.sh
+++ b/bin/templating.sh
@@ -5,7 +5,11 @@
 
 set -eo pipefail
 
-value=${TEMPLATE}
+## Inputs
+template=${TEXT}
+
+## State
+value=${template}
 
 # --- Import ----------------------------------------------------------------- #
 

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -5,7 +5,6 @@
 
 set -eo pipefail
 
-bin_dir=$(dirname "${BASH_SOURCE[0]}")
 exclusions=${NOT}
 inclusions=${ONLY}
 max_capacity=${MAX}
@@ -18,8 +17,10 @@ output_name_updated_tools='updated-tools'
 
 # --- Import ----------------------------------------------------------------- #
 
+bin=$(dirname "${BASH_SOURCE[0]}")
+
 # shellcheck source=./lib/actions.sh
-source "${bin_dir}/../lib/actions.sh"
+source "${bin}/../lib/actions.sh"
 
 # --- Script ----------------------------------------------------------------- #
 

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -5,15 +5,19 @@
 
 set -eo pipefail
 
+## Inputs
 exclusions=${NOT}
 inclusions=${ONLY}
 max_capacity=${MAX}
-remaining_capacity=${MAX}
 skips=${SKIP}
-updated_tools=""
 
+## Constants
 output_name_updated_count="updated-count"
 output_name_updated_tools="updated-tools"
+
+## State
+remaining_capacity=${max_capacity}
+updated_tools=""
 
 # --- Import ----------------------------------------------------------------- #
 

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -10,10 +10,10 @@ inclusions=${ONLY}
 max_capacity=${MAX}
 remaining_capacity=${MAX}
 skips=${SKIP}
-updated_tools=''
+updated_tools=""
 
-output_name_updated_count='updated-count'
-output_name_updated_tools='updated-tools'
+output_name_updated_count="updated-count"
+output_name_updated_tools="updated-tools"
 
 # --- Import ----------------------------------------------------------------- #
 
@@ -29,7 +29,7 @@ set_output "${output_name_updated_count}" "0"
 set_output "${output_name_updated_tools}" "${updated_tools}"
 
 debug "checking if .tool-versions file exists"
-if [[ ! -f '.tool-versions' ]]; then
+if [[ ! -f ".tool-versions" ]]; then
 	error "no .tool-versions file found, it must be present at the root of your project in order for this action to work"
 	exit 1
 fi

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -105,7 +105,7 @@ runs:
       shell: bash
       run: $GITHUB_ACTION_PATH/../bin/templating.sh
       env:
-        TEMPLATE: ${{ inputs.commit-message }}
+        TEXT: ${{ inputs.commit-message }}
         UPDATED_COUNT: ${{ steps.update.outputs.updated-count }}
         UPDATED_TOOLS: ${{ steps.update.outputs.updated-tools }}
     - name: Commit options

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -137,7 +137,7 @@ runs:
       shell: bash
       run: $GITHUB_ACTION_PATH/../bin/templating.sh
       env:
-        TEMPLATE: ${{ inputs.pr-title }}
+        TEXT: ${{ inputs.pr-title }}
         UPDATED_COUNT: ${{ steps.update.outputs.updated-count }}
         UPDATED_TOOLS: ${{ steps.update.outputs.updated-tools }}
     - name: Pull Request body
@@ -145,7 +145,7 @@ runs:
       shell: bash
       run: $GITHUB_ACTION_PATH/../bin/templating.sh
       env:
-        TEMPLATE: ${{ inputs.pr-body }}
+        TEXT: ${{ inputs.pr-body }}
         UPDATED_COUNT: ${{ steps.update.outputs.updated-count }}
         UPDATED_TOOLS: ${{ steps.update.outputs.updated-tools }}
     - name: Commit message
@@ -153,7 +153,7 @@ runs:
       shell: bash
       run: $GITHUB_ACTION_PATH/../bin/templating.sh
       env:
-        TEMPLATE: ${{ inputs.commit-message }}
+        TEXT: ${{ inputs.commit-message }}
         UPDATED_COUNT: ${{ steps.update.outputs.updated-count }}
         UPDATED_TOOLS: ${{ steps.update.outputs.updated-tools }}
 

--- a/spec/bin/templating_spec.sh
+++ b/spec/bin/templating_spec.sh
@@ -7,7 +7,7 @@ Describe 'bin/templating.sh'
 	setup() {
 		export UPDATED_COUNT=2
 		export UPDATED_TOOLS='shellcheck,shellspec'
-		export TEMPLATE="$(input)"
+		export TEXT="$(input)"
 	}
 
 	BeforeEach 'setup'


### PR DESCRIPTION
Relates to #41

## Summary

- Move the definition of `bin_dir` into the import section, which is the only place where it is (and should be) used.
- Use consistent argument quoting.
- Organize script setup into inputs, constants, and state.
- Use constant output name in templating.sh.