### PR TITLE
Check if branch has been updated before updating a Pull Request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Versioning].
 
 ### `tool-versions-update-action/pr`
 
-- _No changes yet._
+- Prevent force pushes to Pull Request that were modified.
 
 ## [0.3.10] - 2023-12-09
 

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -164,16 +164,15 @@ runs:
       shell: bash
       run: |
         if [ -n "$(git rev-parse --verify "origin/${BRANCH}" 2>/dev/null)" ]; then
-          commit_count=$(git rev-list "${BASE}".."origin/${BRANCH}" --count --first-parent)
+          commit_count=$(git rev-list "${BASE}..origin/${BRANCH}" --count)
           if [ "${commit_count}" -gt 1 ]; then
             echo "Pull Request modifications detected, not making changes"
             echo "value=false" >>"${GITHUB_OUTPUT}"
-          else
-            echo "value=true" >>"${GITHUB_OUTPUT}"
+            exit 0
           fi
-        else
-          echo "value=true" >>"${GITHUB_OUTPUT}"
         fi
+
+        echo "value=true" >>"${GITHUB_OUTPUT}"
       env:
         BASE: ${{ inputs.pr-base }}
         BRANCH: ${{ inputs.branch }}

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -108,6 +108,8 @@ runs:
   steps:
     - name: Checkout repository
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
+      with:
+        fetch-depth: 0
 
     - name: Setup asdf
       if: ${{ inputs.plugins != '' }}
@@ -157,7 +159,26 @@ runs:
         UPDATED_COUNT: ${{ steps.update.outputs.updated-count }}
         UPDATED_TOOLS: ${{ steps.update.outputs.updated-tools }}
 
+    - name: Check if a Pull Request exists and has been modified
+      id: do-run
+      shell: bash
+      run: |
+        if [ -n "$(git rev-parse --verify "origin/${BRANCH}" 2>/dev/null)" ]; then
+          commit_count=$(git rev-list "${BASE}".."origin/${BRANCH}" --count --first-parent)
+          if [ "${commit_count}" -gt 1 ]; then
+            echo "Pull Request modifications detected, not making changes"
+            echo "value=false" >>"${GITHUB_OUTPUT}"
+          else
+            echo "value=true" >>"${GITHUB_OUTPUT}"
+          fi
+        else
+          echo "value=true" >>"${GITHUB_OUTPUT}"
+        fi
+      env:
+        BASE: ${{ inputs.pr-base }}
+        BRANCH: ${{ inputs.branch }}
     - name: Create Pull Request
+      if: ${{ steps.do-run.outputs.value == 'true' }}
       id: create-pr
       uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # pin@v5
       with:


### PR DESCRIPTION
Closes #144

## Summary

Update the `/pr` variant of this Action to check if the Pull Request has been updated before trying to create a/update the Pull Request. This is done so that user-made changes on the Pull Request won't be overridden.