### PR TITLE
Add support for multiline output values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ Versioning].
 
 ### `tool-versions-update-action/commit`
 
-- _No changes yet._
+- Fix runtime error when `commit-message` spans multiple lines.
 
 ### `tool-versions-update-action/pr`
 
+- Fix runtime error when any of `commit-message`, `pr-body`, or `pr-title` spans
+  multiple lines.
 - Prevent force pushes to Pull Request that were modified.
 
 ## [0.3.10] - 2023-12-09

--- a/lib/actions.sh
+++ b/lib/actions.sh
@@ -22,5 +22,13 @@ group_end() {
 }
 
 set_output() {
-	echo "$1=$2" >>"${GITHUB_OUTPUT}"
+	if [[ "$(wc -l <<<"$2")" -gt 1 ]]; then
+		{
+			echo "$1<<EOF"
+			echo "$2"
+			echo "EOF"
+		} >>"${GITHUB_OUTPUT}"
+	else
+		echo "$1=$2" >>"${GITHUB_OUTPUT}"
+	fi
 }

--- a/lib/actions.sh
+++ b/lib/actions.sh
@@ -6,11 +6,11 @@ info() {
 }
 
 debug() {
-	echo "::debug::$1"
+	awk '{print "::debug::"$0}' <<<"$1"
 }
 
 error() {
-	echo "::error::$1"
+	awk '{print "::error::"$0}' <<<"$1"
 }
 
 group_start() {

--- a/spec/lib/actions_spec.sh
+++ b/spec/lib/actions_spec.sh
@@ -7,26 +7,66 @@ Describe 'lib/actions.sh'
 	Include lib/actions.sh
 
 	Describe 'debug logging'
-		Parameters
-			'foobar'
-			'Something happened'
+		Describe 'single-line'
+			Parameters
+				'foobar'
+				'Something happened'
+			End
+
+			It "can write a debug log ('$1')"
+				When call debug "$1"
+				The output should equal "::debug::$1"
+			End
 		End
 
-		It "can write a debug log ('$1')"
-			When call debug "$1"
-			The output should equal "::debug::$1"
+		Describe 'multi-line'
+			value() {
+				%text
+				#|foo
+				#|bar
+			}
+			result() {
+				%text
+				#|::debug::foo
+				#|::debug::bar
+			}
+
+			It 'can write an error log'
+				When call debug "$(value)"
+				The output should equal "$(result)"
+			End
 		End
 	End
 
 	Describe 'error logging'
-		Parameters
-			'foobar'
-			'That didn''t go well'
+		Describe 'single-line'
+			Parameters
+				'foobar'
+				'That didn''t go well'
+			End
+
+			It "can write an error log ('$1')"
+				When call error "$1"
+				The output should equal "::error::$1"
+			End
 		End
 
-		It "can write an error log ('$1')"
-			When call error "$1"
-			The output should equal "::error::$1"
+		Describe 'multi-line'
+			value() {
+				%text
+				#|hello
+				#|world
+			}
+			result() {
+				%text
+				#|::error::hello
+				#|::error::world
+			}
+
+			It 'can write an error log'
+				When call error "$(value)"
+				The output should equal "$(result)"
+			End
 		End
 	End
 

--- a/spec/lib/actions_spec.sh
+++ b/spec/lib/actions_spec.sh
@@ -100,5 +100,24 @@ Describe 'lib/actions.sh'
 				The file "${GITHUB_OUTPUT}" should satisfy contents "$(result)"
 			End
 		End
+
+		It 'can output a multi-line value'
+			value() {
+				%text
+				#|hello
+				#|world
+			}
+			result() {
+				%text
+				#|multiline<<EOF
+				#|hello
+				#|world
+				#|EOF
+			}
+
+			When call set_output 'multiline' "$(value)"
+			The output should equal ''
+			The file "${GITHUB_OUTPUT}" should satisfy contents "$(result)"
+		End
 	End
 End


### PR DESCRIPTION
Closes #161
Relates to #156

## Summary

Add support for multi-line output values to the `set_output` helper function.