### PR TITLE
Add outputs `updated-old-versions` and `updated-new-versions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,18 @@ Versioning].
 
 ### `tool-versions-update-action`
 
-- _No changes yet._
+- Add output `updated-new-versions`.
+- Add output `updated-old-versions`.
 
 ### `tool-versions-update-action/commit`
 
-- _No changes yet._
+- Add output `updated-new-versions`.
+- Add output `updated-old-versions`.
 
 ### `tool-versions-update-action/pr`
 
-- _No changes yet._
+- Add output `updated-new-versions`.
+- Add output `updated-old-versions`.
 
 ## [0.3.11] - 2023-12-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,13 @@ Versioning].
 
 ### `tool-versions-update-action/commit`
 
-- Add output `updated-new-versions`.
-- Add output `updated-old-versions`.
+- Add output `updated-new-versions`, which can also be used for templating.
+- Add output `updated-old-versions`, which can also be used for templating.
 
 ### `tool-versions-update-action/pr`
 
-- Add output `updated-new-versions`.
-- Add output `updated-old-versions`.
+- Add output `updated-new-versions`, which can also be used for templating.
+- Add output `updated-old-versions`, which can also be used for templating.
 
 ## [0.3.11] - 2023-12-13
 

--- a/README.md
+++ b/README.md
@@ -58,11 +58,13 @@ sub-actions to get up-and-running quickly with one-step automated tooling jobs.
 
 The following outputs are made available:
 
-| Name            | Description                                                |
-| --------------- | ---------------------------------------------------------- |
-| `did-update`    | `true` if at least one tool was updated, `false` otherwise |
-| `updated-count` | The number of tools that were updated                      |
-| `updated-tools` | A comma separated list of the names of the updated tools   |
+| Name                   | Description                                                 |
+| ---------------------- | ----------------------------------------------------------- |
+| `did-update`           | `true` if at least one tool was updated, `false` otherwise  |
+| `updated-count`        | The number of tools that were updated                       |
+| `updated-new-versions` | A comma separated list of the new versions of updated tools |
+| `updated-old-versions` | A comma separated list of the old versions of updated tools |
+| `updated-tools`        | A comma separated list of the names of the updated tools    |
 
 For information on how to use outputs see the [GitHub Actions output docs].
 

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,12 @@ outputs:
   updated-count:
     description: The number of tools that were updated.
     value: ${{ steps.update.outputs.updated-count }}
+  updated-new-versions:
+    description: A comma separated list of the new versions of updated tools.
+    value: ${{ steps.update.outputs.new-versions }}
+  updated-old-versions:
+    description: A comma separated list of the old versions of updated tools.
+    value: ${{ steps.update.outputs.old-versions }}
   updated-tools:
     description: A comma separated list of the names of the updated tools.
     value: ${{ steps.update.outputs.updated-tools }}

--- a/bin/templating.sh
+++ b/bin/templating.sh
@@ -28,6 +28,12 @@ debug "input for templating is '${value}'"
 debug "substitute '{{updated-count}}' for '${UPDATED_COUNT}'"
 value=${value//'{{updated-count}}'/"${UPDATED_COUNT}"}
 
+debug "substitute '{{updated-new-versions}}' for '${UPDATED_NEW_VERSIONS}'"
+value=${value//'{{updated-new-versions}}'/"${UPDATED_NEW_VERSIONS}"}
+
+debug "substitute '{{updated-old-versions}}' for '${UPDATED_OLD_VERSIONS}'"
+value=${value//'{{updated-old-versions}}'/"${UPDATED_OLD_VERSIONS}"}
+
 debug "substitute '{{updated-tools}}' for '${UPDATED_TOOLS}'"
 value=${value//'{{updated-tools}}'/"${UPDATED_TOOLS}"}
 

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -30,6 +30,16 @@ bin=$(dirname "${BASH_SOURCE[0]}")
 # shellcheck source=./lib/actions.sh
 source "${bin}/../lib/actions.sh"
 
+# --- Helpers ---------------------------------------------------------------- #
+
+extend_list() {
+	if [ -z "$1" ]; then
+		echo "$2"
+	else
+		echo "$1,$2"
+	fi
+}
+
 # --- Script ----------------------------------------------------------------- #
 
 debug "initializing outputs to their default value"
@@ -130,27 +140,15 @@ while read -r line; do
 			set_output "${output_name_updated_count}" "$((max_capacity - remaining_capacity))"
 
 			debug "overriding '${output_name_updated_tools}' output with new value"
-			if [ -z "${updated_tools}" ]; then
-				updated_tools="${tool}"
-			else
-				updated_tools="${updated_tools},${tool}"
-			fi
+			updated_tools="$(extend_list "${updated_tools}" "${tool}")"
 			set_output "${output_name_updated_tools}" "${updated_tools}"
 
 			debug "overriding '${output_name_updated_old_versions}' output with new value"
-			if [ -z "${updated_old_versions}" ]; then
-				updated_old_versions="${current_version}"
-			else
-				updated_old_versions="${updated_old_versions},${current_version}"
-			fi
+			updated_old_versions="$(extend_list "${updated_old_versions}" "${current_version}")"
 			set_output "${output_name_updated_old_versions}" "${updated_old_versions}"
 
 			debug "overriding '${output_name_updated_new_versions}' output with new value"
-			if [ -z "${updated_new_versions}" ]; then
-				updated_new_versions="${latest_version}"
-			else
-				updated_new_versions="${updated_new_versions},${latest_version}"
-			fi
+			updated_new_versions="$(extend_list "${updated_new_versions}" "${latest_version}")"
 			set_output "${output_name_updated_new_versions}" "${updated_new_versions}"
 
 			if [ "${remaining_capacity}" -eq 0 ]; then

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -14,10 +14,14 @@ skips=${SKIP}
 ## Constants
 output_name_updated_count="updated-count"
 output_name_updated_tools="updated-tools"
+output_name_updated_old_versions="updated-old-versions"
+output_name_updated_new_versions="updated-new-versions"
 
 ## State
 remaining_capacity=${max_capacity}
 updated_tools=""
+updated_old_versions=""
+updated_new_versions=""
 
 # --- Import ----------------------------------------------------------------- #
 
@@ -31,6 +35,8 @@ source "${bin}/../lib/actions.sh"
 debug "initializing outputs to their default value"
 set_output "${output_name_updated_count}" "0"
 set_output "${output_name_updated_tools}" "${updated_tools}"
+set_output "${output_name_updated_old_versions}" "${updated_old_versions}"
+set_output "${output_name_updated_new_versions}" "${updated_new_versions}"
 
 debug "checking if .tool-versions file exists"
 if [[ ! -f ".tool-versions" ]]; then
@@ -130,6 +136,22 @@ while read -r line; do
 				updated_tools="${updated_tools},${tool}"
 			fi
 			set_output "${output_name_updated_tools}" "${updated_tools}"
+
+			debug "overriding '${output_name_updated_old_versions}' output with new value"
+			if [ -z "${updated_old_versions}" ]; then
+				updated_old_versions="${current_version}"
+			else
+				updated_old_versions="${updated_old_versions},${current_version}"
+			fi
+			set_output "${output_name_updated_old_versions}" "${updated_old_versions}"
+
+			debug "overriding '${output_name_updated_new_versions}' output with new value"
+			if [ -z "${updated_new_versions}" ]; then
+				updated_new_versions="${latest_version}"
+			else
+				updated_new_versions="${updated_new_versions},${latest_version}"
+			fi
+			set_output "${output_name_updated_new_versions}" "${updated_new_versions}"
 
 			if [ "${remaining_capacity}" -eq 0 ]; then
 				info "finished updating after ${max_capacity} update(s)"

--- a/commit/README.md
+++ b/commit/README.md
@@ -70,12 +70,14 @@ file through a commit.
 
 The following outputs are made available:
 
-| Name            | Description                                                |
-| --------------- | ---------------------------------------------------------- |
-| `commit-sha`    | The SHA identifier of the created commit                   |
-| `did-update`    | `true` if at least one tool was updated, `false` otherwise |
-| `updated-count` | The number of tools that were updated                      |
-| `updated-tools` | A comma separated list of the names of the updated tools   |
+| Name                   | Description                                                 |
+| ---------------------- | ----------------------------------------------------------- |
+| `commit-sha`           | The SHA identifier of the created commit                    |
+| `did-update`           | `true` if at least one tool was updated, `false` otherwise  |
+| `updated-count`        | The number of tools that were updated                       |
+| `updated-new-versions` | A comma separated list of the new versions of updated tools |
+| `updated-old-versions` | A comma separated list of the old versions of updated tools |
+| `updated-tools`        | A comma separated list of the names of the updated tools    |
 
 For information on how to use outputs see the [GitHub Actions output docs].
 

--- a/commit/README.md
+++ b/commit/README.md
@@ -104,6 +104,8 @@ The following inputs support templating:
 The following outputs are available for templating:
 
 - `updated-count`
+- `updated-new-versions`
+- `updated-old-versions`
 - `updated-tools`
 
 ### Full Example

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -64,6 +64,12 @@ outputs:
   updated-count:
     description: The number of tools that were updated.
     value: ${{ steps.update.outputs.updated-count }}
+  updated-new-versions:
+    description: A comma separated list of the new versions of updated tools.
+    value: ${{ steps.update.outputs.new-versions }}
+  updated-old-versions:
+    description: A comma separated list of the old versions of updated tools.
+    value: ${{ steps.update.outputs.old-versions }}
   updated-tools:
     description: A comma separated list of the names of the updated tools.
     value: ${{ steps.update.outputs.updated-tools }}

--- a/pr/README.md
+++ b/pr/README.md
@@ -150,6 +150,8 @@ The following inputs support templating:
 The following outputs are available for templating:
 
 - `updated-count`
+- `updated-new-versions`
+- `updated-old-versions`
 - `updated-tools`
 
 ### Full Example

--- a/pr/README.md
+++ b/pr/README.md
@@ -113,13 +113,15 @@ file through a Pull Request.
 
 The following outputs are made available:
 
-| Name            | Description                                                |
-| --------------- | ---------------------------------------------------------- |
-| `commit-sha`    | The SHA identifier of the created commit                   |
-| `did-update`    | `true` if at least one tool was updated, `false` otherwise |
-| `pr-number`     | The number of the created Pull Request                     |
-| `updated-count` | The number of tools that were updated                      |
-| `updated-tools` | A comma separated list of the names of the updated tools   |
+| Name                   | Description                                                 |
+| ---------------------- | ----------------------------------------------------------- |
+| `commit-sha`           | The SHA identifier of the created commit                    |
+| `did-update`           | `true` if at least one tool was updated, `false` otherwise  |
+| `pr-number`            | The number of the created Pull Request                      |
+| `updated-count`        | The number of tools that were updated                       |
+| `updated-new-versions` | A comma separated list of the new versions of updated tools |
+| `updated-old-versions` | A comma separated list of the old versions of updated tools |
+| `updated-tools`        | A comma separated list of the names of the updated tools    |
 
 For information on how to use outputs see the [GitHub Actions output docs].
 

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -99,6 +99,12 @@ outputs:
   updated-count:
     description: The number of tools that were updated.
     value: ${{ steps.update.outputs.updated-count }}
+  updated-new-versions:
+    description: A comma separated list of the new versions of updated tools.
+    value: ${{ steps.update.outputs.new-versions }}
+  updated-old-versions:
+    description: A comma separated list of the old versions of updated tools.
+    value: ${{ steps.update.outputs.old-versions }}
   updated-tools:
     description: A comma separated list of the names of the updated tools.
     value: ${{ steps.update.outputs.updated-tools }}

--- a/spec/bin/templating_spec.sh
+++ b/spec/bin/templating_spec.sh
@@ -6,6 +6,8 @@ BeforeEach 'clear_github_output'
 Describe 'bin/templating.sh'
 	setup() {
 		export UPDATED_COUNT=2
+		export UPDATED_NEW_VERSIONS='0.9.0,0.28.1'
+		export UPDATED_OLD_VERSIONS='0.8.0,0.28.0'
 		export UPDATED_TOOLS='shellcheck,shellspec'
 		export TEXT="$(input)"
 	}
@@ -22,6 +24,8 @@ Describe 'bin/templating.sh'
 			%text
 			#|::debug::input for templating is 'Update {{updated-count}} tool(s)'
 			#|::debug::substitute '{{updated-count}}' for '2'
+			#|::debug::substitute '{{updated-new-versions}}' for '0.9.0,0.28.1'
+			#|::debug::substitute '{{updated-old-versions}}' for '0.8.0,0.28.0'
 			#|::debug::substitute '{{updated-tools}}' for 'shellcheck,shellspec'
 			#|::debug::setting output
 		}
@@ -29,6 +33,64 @@ Describe 'bin/templating.sh'
 		snapshot_output() {
 			%text
 			#|value=Update 2 tool(s)
+		}
+
+		It 'works for a simple example'
+			When run script bin/templating.sh
+			The status should equal 0
+			The output should equal "$(snapshot_stdout)"
+			The file "${GITHUB_OUTPUT}" should satisfy contents "$(snapshot_output)"
+		End
+	End
+
+	Describe '{{updated-new-versions}}'
+		input() {
+			%text
+			#|The new versions are {{updated-new-versions}}
+		}
+
+		snapshot_stdout() {
+			%text
+			#|::debug::input for templating is 'The new versions are {{updated-new-versions}}'
+			#|::debug::substitute '{{updated-count}}' for '2'
+			#|::debug::substitute '{{updated-new-versions}}' for '0.9.0,0.28.1'
+			#|::debug::substitute '{{updated-old-versions}}' for '0.8.0,0.28.0'
+			#|::debug::substitute '{{updated-tools}}' for 'shellcheck,shellspec'
+			#|::debug::setting output
+		}
+
+		snapshot_output() {
+			%text
+			#|value=The new versions are 0.9.0,0.28.1
+		}
+
+		It 'works for a simple example'
+			When run script bin/templating.sh
+			The status should equal 0
+			The output should equal "$(snapshot_stdout)"
+			The file "${GITHUB_OUTPUT}" should satisfy contents "$(snapshot_output)"
+		End
+	End
+
+	Describe '{{updated-old-versions}}'
+		input() {
+			%text
+			#|The old versions are {{updated-old-versions}}
+		}
+
+		snapshot_stdout() {
+			%text
+			#|::debug::input for templating is 'The old versions are {{updated-old-versions}}'
+			#|::debug::substitute '{{updated-count}}' for '2'
+			#|::debug::substitute '{{updated-new-versions}}' for '0.9.0,0.28.1'
+			#|::debug::substitute '{{updated-old-versions}}' for '0.8.0,0.28.0'
+			#|::debug::substitute '{{updated-tools}}' for 'shellcheck,shellspec'
+			#|::debug::setting output
+		}
+
+		snapshot_output() {
+			%text
+			#|value=The old versions are 0.8.0,0.28.0
 		}
 
 		It 'works for a simple example'
@@ -49,6 +111,8 @@ Describe 'bin/templating.sh'
 			%text
 			#|::debug::input for templating is 'Update tool(s) {{updated-tools}}'
 			#|::debug::substitute '{{updated-count}}' for '2'
+			#|::debug::substitute '{{updated-new-versions}}' for '0.9.0,0.28.1'
+			#|::debug::substitute '{{updated-old-versions}}' for '0.8.0,0.28.0'
 			#|::debug::substitute '{{updated-tools}}' for 'shellcheck,shellspec'
 			#|::debug::setting output
 		}

--- a/spec/bin/update_spec.sh
+++ b/spec/bin/update_spec.sh
@@ -104,6 +104,8 @@ Describe 'bin/update.sh'
 			%text
 			#|updated-count=0
 			#|updated-tools=
+			#|updated-old-versions=
+			#|updated-new-versions=
 		}
 
 		It 'succeeds'
@@ -156,6 +158,8 @@ Describe 'bin/update.sh'
 			#|::debug::remaining update capacity: -1
 			#|::debug::overriding 'updated-count' output with new value
 			#|::debug::overriding 'updated-tools' output with new value
+			#|::debug::overriding 'updated-old-versions' output with new value
+			#|::debug::overriding 'updated-new-versions' output with new value
 			#|::debug::processing line ('shellspec 0.28.0')
 			#|evaluating shellspec...
 			#|::debug::shellspec current: 0.28.0, latest: 0.28.1
@@ -165,6 +169,8 @@ Describe 'bin/update.sh'
 			#|::debug::remaining update capacity: -2
 			#|::debug::overriding 'updated-count' output with new value
 			#|::debug::overriding 'updated-tools' output with new value
+			#|::debug::overriding 'updated-old-versions' output with new value
+			#|::debug::overriding 'updated-new-versions' output with new value
 			#|::debug::processing line ('shfmt 3.6.1')
 			#|evaluating shfmt...
 			#|::debug::shfmt current: 3.6.1, latest: 3.7.0
@@ -174,6 +180,8 @@ Describe 'bin/update.sh'
 			#|::debug::remaining update capacity: -3
 			#|::debug::overriding 'updated-count' output with new value
 			#|::debug::overriding 'updated-tools' output with new value
+			#|::debug::overriding 'updated-old-versions' output with new value
+			#|::debug::overriding 'updated-new-versions' output with new value
 			#|::endgroup::
 		}
 
@@ -181,12 +189,20 @@ Describe 'bin/update.sh'
 			%text
 			#|updated-count=0
 			#|updated-tools=
+			#|updated-old-versions=
+			#|updated-new-versions=
 			#|updated-count=1
 			#|updated-tools=shellcheck
+			#|updated-old-versions=0.8.0
+			#|updated-new-versions=0.9.0
 			#|updated-count=2
 			#|updated-tools=shellcheck,shellspec
+			#|updated-old-versions=0.8.0,0.28.0
+			#|updated-new-versions=0.9.0,0.28.1
 			#|updated-count=3
 			#|updated-tools=shellcheck,shellspec,shfmt
+			#|updated-old-versions=0.8.0,0.28.0,3.6.1
+			#|updated-new-versions=0.9.0,0.28.1,3.7.0
 		}
 
 		It 'succeeds'
@@ -239,6 +255,8 @@ Describe 'bin/update.sh'
 			#|::debug::remaining update capacity: 1
 			#|::debug::overriding 'updated-count' output with new value
 			#|::debug::overriding 'updated-tools' output with new value
+			#|::debug::overriding 'updated-old-versions' output with new value
+			#|::debug::overriding 'updated-new-versions' output with new value
 			#|::debug::processing line ('shellspec 0.28.0')
 			#|evaluating shellspec...
 			#|::debug::shellspec current: 0.28.0, latest: 0.28.1
@@ -248,6 +266,8 @@ Describe 'bin/update.sh'
 			#|::debug::remaining update capacity: 0
 			#|::debug::overriding 'updated-count' output with new value
 			#|::debug::overriding 'updated-tools' output with new value
+			#|::debug::overriding 'updated-old-versions' output with new value
+			#|::debug::overriding 'updated-new-versions' output with new value
 			#|finished updating after 2 update(s)
 			#|::endgroup::
 		}
@@ -256,10 +276,16 @@ Describe 'bin/update.sh'
 			%text
 			#|updated-count=0
 			#|updated-tools=
+			#|updated-old-versions=
+			#|updated-new-versions=
 			#|updated-count=1
 			#|updated-tools=shellcheck
+			#|updated-old-versions=0.8.0
+			#|updated-new-versions=0.9.0
 			#|updated-count=2
 			#|updated-tools=shellcheck,shellspec
+			#|updated-old-versions=0.8.0,0.28.0
+			#|updated-new-versions=0.9.0,0.28.1
 		}
 
 		It 'succeeds'
@@ -315,6 +341,8 @@ Describe 'bin/update.sh'
 			#|::debug::remaining update capacity: -1
 			#|::debug::overriding 'updated-count' output with new value
 			#|::debug::overriding 'updated-tools' output with new value
+			#|::debug::overriding 'updated-old-versions' output with new value
+			#|::debug::overriding 'updated-new-versions' output with new value
 			#|::endgroup::
 		}
 
@@ -322,8 +350,12 @@ Describe 'bin/update.sh'
 			%text
 			#|updated-count=0
 			#|updated-tools=
+			#|updated-old-versions=
+			#|updated-new-versions=
 			#|updated-count=1
 			#|updated-tools=shellspec
+			#|updated-old-versions=0.28.0
+			#|updated-new-versions=0.28.1
 		}
 
 		It 'succeeds'
@@ -376,6 +408,8 @@ Describe 'bin/update.sh'
 			#|::debug::remaining update capacity: -1
 			#|::debug::overriding 'updated-count' output with new value
 			#|::debug::overriding 'updated-tools' output with new value
+			#|::debug::overriding 'updated-old-versions' output with new value
+			#|::debug::overriding 'updated-new-versions' output with new value
 			#|::debug::processing line ('shellspec 0.28.0')
 			#|::debug::checking if shellspec is NOT in the inclusion input
 			#|skipping shellspec because it is NOT in the inclusion input
@@ -386,8 +420,12 @@ Describe 'bin/update.sh'
 			%text
 			#|updated-count=0
 			#|updated-tools=
+			#|updated-old-versions=
+			#|updated-new-versions=
 			#|updated-count=1
 			#|updated-tools=shellcheck
+			#|updated-old-versions=0.8.0
+			#|updated-new-versions=0.9.0
 		}
 
 		It 'succeeds'
@@ -453,6 +491,8 @@ Describe 'bin/update.sh'
 			#|::debug::remaining update capacity: -1
 			#|::debug::overriding 'updated-count' output with new value
 			#|::debug::overriding 'updated-tools' output with new value
+			#|::debug::overriding 'updated-old-versions' output with new value
+			#|::debug::overriding 'updated-new-versions' output with new value
 			#|::endgroup::
 		}
 
@@ -460,8 +500,12 @@ Describe 'bin/update.sh'
 			%text
 			#|updated-count=0
 			#|updated-tools=
+			#|updated-old-versions=
+			#|updated-new-versions=
 			#|updated-count=1
 			#|updated-tools=shellspec
+			#|updated-old-versions=0.28.0
+			#|updated-new-versions=0.28.1
 		}
 
 		It 'succeeds'
@@ -598,6 +642,8 @@ Describe 'bin/update.sh'
 			%text
 			#|updated-count=0
 			#|updated-tools=
+			#|updated-old-versions=
+			#|updated-new-versions=
 		}
 
 		remove_tool_versions() {


### PR DESCRIPTION
Closes #166

## Summary

Update the main script to set the both the `updated-old-versions` and `updated-new-versions` outputs initially to an empty string and updating it with the tool's old and new version (resp.) every time a tool update was successful. It is implemented to generate a comma separate list, w/o any leading or trailing commas. Like previous outputs the implementation leverages the fact that newer values override old values.

Update each Action manifest to expose this script/step output as an Action output, as well as update the docs and changelog accordingly.

The new behaviour is also tested through the existing test suite with updated snapshots.