### PR TITLE
Update default `commit-message` and `pr-body` values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,13 @@ Versioning].
 
 - Add output `updated-new-versions`, which can also be used for templating.
 - Add output `updated-old-versions`, which can also be used for templating.
+- Update default `commit-message`.
 
 ### `tool-versions-update-action/pr`
 
 - Add output `updated-new-versions`, which can also be used for templating.
 - Add output `updated-old-versions`, which can also be used for templating.
+- Update default `commit-message` and `pr-body`.
 
 ## [0.3.11] - 2023-12-13
 

--- a/commit/README.md
+++ b/commit/README.md
@@ -20,8 +20,11 @@ file through a commit.
     # This input supports templating, see the "Templating" section for more
     # information.
     #
-    # Default: "Update {{updated-tools}}"
-    commit-message: Update {{updated-count}} tool(s) ({{updated-tools}})
+    # Default (1st line): "Update {{updated-tools}}"
+    commit-message: |
+      Update {{updated-count}} tool(s)
+
+      Update {{updated-tools}}
 
     # The maximum number of tools to update. 0 indicates no maximum.
     #

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -14,7 +14,12 @@ inputs:
     description: |
       The message to use for commits.
     required: false
-    default: Update {{updated-tools}}
+    default: |
+      Update {{updated-tools}}
+
+      Update {{updated-count}} tool(s): {{updated-tools}}
+      - Version(s) before: {{updated-old-versions}}
+      - Version(s) after:  {{updated-new-versions}}
   max:
     description: |
       The maximum number of tools to update. 0 indicates no maximum.

--- a/pr/README.md
+++ b/pr/README.md
@@ -26,8 +26,11 @@ file through a Pull Request.
     # This input supports templating, see the "Templating" section for more
     # information.
     #
-    # Default: "Update {{updated-tools}}"
-    commit-message: Update {{updated-count}} tool(s) ({{updated-tools}})
+    # Default (1st line): "Update {{updated-tools}}"
+    commit-message: |
+      Update {{updated-count}} tool(s)
+
+      Update {{updated-tools}}
 
     # A comma or newline-separated list of labels for Pull Requests.
     #
@@ -67,7 +70,7 @@ file through a Pull Request.
     # This input supports templating, see the "Templating" section for more
     # information.
     #
-    # Default: "Update {{updated-count}} tool(s) ({{updated-tools}})"
+    # Default (1st line): "Update {{updated-count}} tool(s): {{updated-tools}}"
     pr-body: |
       Update {{updated-count}} tool(s): {{updated-tools}}
 

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -20,7 +20,12 @@ inputs:
     description: |
       The message to use for commits.
     required: false
-    default: Update {{updated-tools}}
+    default: |
+      Update {{updated-tools}}
+
+      Update {{updated-count}} tool(s): {{updated-tools}}
+      - Version(s) before: {{updated-old-versions}}
+      - Version(s) after:  {{updated-new-versions}}
   labels:
     description: |
       A comma or newline-separated list of labels for Pull Requests.
@@ -56,7 +61,25 @@ inputs:
     description: |
       The body text to use for Pull Requests.
     required: false
-    default: Update {{updated-count}} tool(s) ({{updated-tools}})
+    default: >
+      Update {{updated-count}} tool(s): {{updated-tools}}
+
+      - Version(s) before: {{updated-old-versions}}
+
+      - Version(s) after: {{updated-new-versions}}
+
+      ---
+
+      This Pull Request was created by the [tool-versions-update-action]. This
+      Pull Request will be updated automatically as long as you don't alter it
+      yourself.
+
+      - If the base changes, the Pull Request will be rebased automatically.
+
+      - If new tool version become available, those will be included in the Pull
+        Request (in accordance with the update configuration).
+
+      [tool-versions-update-action]: https://github.com/ericcornelissen/tool-versions-update-action
   pr-title:
     description: |
       The title to use for Pull Requests.


### PR DESCRIPTION
Relates to #156, #167

## Summary

Change the default values for the `commit-message` input (`/commit` and `/pr` variant) and the `pr-body` input (`/pr` variant). The aim with these changes is to provide more detailed and useful information in the defaults. In particular for the `pr-body`, which now includes an explanation of the behavior of the Pull Request.