### PR TITLE
Update formatting of the default `pr-body` value

### DIFF
--- a/pr/action.yml
+++ b/pr/action.yml
@@ -61,21 +61,15 @@ inputs:
     description: |
       The body text to use for Pull Requests.
     required: false
-    default: >
+    default: |
       Update {{updated-count}} tool(s): {{updated-tools}}
-
       - Version(s) before: {{updated-old-versions}}
-
       - Version(s) after: {{updated-new-versions}}
 
       ---
 
-      This Pull Request was created by the [tool-versions-update-action]. This
-      Pull Request will be updated automatically as long as you don't alter it
-      yourself.
-
+      This Pull Request was created by the [tool-versions-update-action]. This Pull Request will be updated automatically as long as you don't alter it yourself.
       - If the base changes, the Pull Request will be rebased automatically.
-
       - If new tool version become available, those will be included in the Pull
         Request (in accordance with the update configuration).
 


### PR DESCRIPTION
Relates to #168, #170

## Summary

Change the default `pr-body` value formatting because the npm utility [pin-github-action], used in the `make update-actions` command, changes the formatting automatically leading to either unexpected changes locally or unnecessary Pull Requests from the `transitive-actions.yml` CI workflow.

[pin-github-action]: https://www.npmjs.com/package/pin-github-action