### PR TITLE
Provide values for templating `updated-(new|old)-versions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,14 @@ Versioning].
 ### `tool-versions-update-action/commit`
 
 - Don't commit if there are no updates.
+- Fix `{{updated-new-versions}}` and `{{updated-old-versions}}` being replaced
+  with an empty string when templating.
 
 ### `tool-versions-update-action/pr`
 
 - Don't open a Pull Request if there are no updates.
+- Fix `{{updated-new-versions}}` and `{{updated-old-versions}}` being replaced
+  with an empty string when templating.
 
 ## [0.3.12] - 2023-12-18
 

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -118,6 +118,8 @@ runs:
       env:
         TEXT: ${{ inputs.commit-message }}
         UPDATED_COUNT: ${{ steps.update.outputs.updated-count }}
+        UPDATED_NEW_VERSIONS: ${{ steps.update.outputs.updated-new-versions }}
+        UPDATED_OLD_VERSIONS: ${{ steps.update.outputs.updated-old-versions }}
         UPDATED_TOOLS: ${{ steps.update.outputs.updated-tools }}
     - name: Commit options
       id: commit-options

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -164,6 +164,8 @@ runs:
       env:
         TEXT: ${{ inputs.pr-title }}
         UPDATED_COUNT: ${{ steps.update.outputs.updated-count }}
+        UPDATED_NEW_VERSIONS: ${{ steps.update.outputs.updated-new-versions }}
+        UPDATED_OLD_VERSIONS: ${{ steps.update.outputs.updated-old-versions }}
         UPDATED_TOOLS: ${{ steps.update.outputs.updated-tools }}
     - name: Pull Request body
       id: pr-body
@@ -172,6 +174,8 @@ runs:
       env:
         TEXT: ${{ inputs.pr-body }}
         UPDATED_COUNT: ${{ steps.update.outputs.updated-count }}
+        UPDATED_NEW_VERSIONS: ${{ steps.update.outputs.updated-new-versions }}
+        UPDATED_OLD_VERSIONS: ${{ steps.update.outputs.updated-old-versions }}
         UPDATED_TOOLS: ${{ steps.update.outputs.updated-tools }}
     - name: Commit message
       id: commit-message
@@ -180,6 +184,8 @@ runs:
       env:
         TEXT: ${{ inputs.commit-message }}
         UPDATED_COUNT: ${{ steps.update.outputs.updated-count }}
+        UPDATED_NEW_VERSIONS: ${{ steps.update.outputs.updated-new-versions }}
+        UPDATED_OLD_VERSIONS: ${{ steps.update.outputs.updated-old-versions }}
         UPDATED_TOOLS: ${{ steps.update.outputs.updated-tools }}
 
     - name: Check if a Pull Request exists and has been modified


### PR DESCRIPTION
Relates to #167

## Summary

Fix a bug where `{{updated-new-versions}}` and `{{updated-old-versions}}` wouldn't be templated correctly because the when the templating script was invoked the values weren't provided.