### PR TITLE
Make container intent explicit in the file name

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,7 +20,7 @@ indent_style=tab
 indent_size=2
 indent_style=space
 
-[Containerfile]
+[Containerfile*]
 indent_size=4
 indent_style=tab
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 !/.version
 
 ## Build tooling
-!/Containerfile
+!/Containerfile.dev
 !/Makefile
 
 ## Configuration

--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -1,8 +1,6 @@
 # Check out Docker at: https://www.docker.com/
 # Check out Podman at: https://podman.io/
 
-# NOTE: THIS IMAGE IS INTENDED FOR DEVELOPMENT PURPOSES ONLY
-
 FROM alpine:3.18.4
 
 RUN apk add --no-cache \

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ lint-ci: $(ASDF) ## Lint CI workflow files
 	@actionlint
 
 lint-container: $(ASDF) ## Lint the Containerfile
-	@hadolint Containerfile
+	@hadolint Containerfile.dev
 
 lint-sh: $(ASDF) ## Lint shell scripts
 	@shellcheck $(SHELL_SCRIPTS) $(SPEC_SCRIPTS)
@@ -107,6 +107,6 @@ $(ASDF): .tool-versions | $(TMP_DIR)
 	@asdf install
 	@touch $(ASDF)
 
-$(DEV_IMG): .tool-versions Containerfile | $(TMP_DIR)
-	@$(CONTAINER_ENGINE) build --file Containerfile --tag $(DEV_IMG_NAME) .
+$(DEV_IMG): .tool-versions Containerfile.dev | $(TMP_DIR)
+	@$(CONTAINER_ENGINE) build --file Containerfile.dev --tag $(DEV_IMG_NAME) .
 	@touch $(DEV_IMG)


### PR DESCRIPTION
Relates to #134, #136

## Summary

Rename `Containerfile` to `Containerfile.dev` to make the intent, previously stated inside, of the file more explicit. This also avoids container engines from "just" building the container when inside the directory, which might be done without knowing the intent of the container.