### PR TITLE
Make Containerfile license explicit

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT-0
+
 # Check out Docker at: https://www.docker.com/
 # Check out Podman at: https://podman.io/
 


### PR DESCRIPTION
Relates to #44

## Summary

Add an explicit license to the `Containerfile`. As a supporting artifact, like [scripts](https://github.com/ericcornelissen/tool-versions-update-action/tree/3e8b1734a4bec2c9daddac2e8d59460647b632cd/script), it's licensed more permissively than the project's main source code.