### PR TITLE
Add input `milestone` to the `/pr` action variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ Versioning].
 
 ### `tool-versions-update-action/pr`
 
-- _No changes yet._
+- Add input `milestone` to set the milestone to be associated with Pull
+  Request.
 
 ## [0.3.13] - 2023-12-22
 

--- a/pr/README.md
+++ b/pr/README.md
@@ -42,6 +42,11 @@ file through a Pull Request.
     # Default: 0
     max: 2
 
+    # The numeric identifier of the milestone to associate the Pull Request to.
+    #
+    # Default: *no milestone*
+    milestone: 1
+
     # A comma-separated list of tools that should NOT be updated.
     #
     # Default: ""

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -36,6 +36,10 @@ inputs:
       The maximum number of tools to update. 0 indicates no maximum.
     required: false
     default: 0
+  milestone:
+    description: |
+      The numeric identifier of the milestone to associate the Pull Request to.
+    required: false
   not:
     description: |
       A comma-separated list of tools that should NOT be updated.
@@ -219,6 +223,7 @@ runs:
         reviewers: ${{ inputs.reviewers }}
         assignees: ${{ inputs.assignees }}
         labels: ${{ inputs.labels }}
+        milestone: ${{ inputs.milestone }}
 
         # Branch
         branch: ${{ inputs.branch }}


### PR DESCRIPTION
## Summary

Add input `milestone` to allow users to set the [Milestone](hhttps://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) to associate the Pull Requests.