### PR TITLE
Use fully qualified base image name for dev-env

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -3,7 +3,7 @@
 # Check out Docker at: https://www.docker.com/
 # Check out Podman at: https://podman.io/
 
-FROM alpine:3.18.4
+FROM docker.io/alpine:3.18.4
 
 RUN apk add --no-cache \
 	bash curl git jq make python3 py3-pip


### PR DESCRIPTION
Relates to #134

## Summary

Improve compatibility of the Containerfile with non-Docker engines.