### PR TITLE
Make `Makefile` license explicit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT-0
+
 CONTAINER_ENGINE?=docker
 
 SHELL_SCRIPTS:=./bin/*.sh ./lib/*.sh


### PR DESCRIPTION
Relates to #44, #178

## Summary

Add an explicit license to the `Makefile`. As a supporting artifact, like the [`Containerfile`](https://github.com/ericcornelissen/tool-versions-update-action/blob/07f4aa27c9d8784d27c6956962e16bc37dc6dd56/Containerfile.dev) and [scripts](https://github.com/ericcornelissen/tool-versions-update-action/tree/3e8b1734a4bec2c9daddac2e8d59460647b632cd/script), it's licensed more permissively than the project's main source code.