### PR TITLE
Update v0 references to v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The first stable release (if reached) will be v1.0.0.
 ## Usage
 
 ```yml
-- uses: ericcornelissen/tool-versions-update-action@v0
+- uses: ericcornelissen/tool-versions-update-action@v1
   with:
     # The maximum number of tools to update. 0 indicates no maximum.
     #
@@ -94,7 +94,7 @@ jobs:
       #   run: |
       #     asdf plugin add example https://github.com/ericcornelissen/asdf-example
       - name: Update tooling
-        uses: ericcornelissen/tool-versions-update-action/commit@v0
+        uses: ericcornelissen/tool-versions-update-action/commit@v1
         id: tooling
         with:
           max: 2

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,7 +3,7 @@
 # Release Guidelines
 
 To release a new version of the _Tool Versions Update Action_ follow the steps
-found in this file (using v0.1.2 as an example):
+found in this file (using v1.2.3 as an example):
 
 1. Make sure that your local copy of the repository is up-to-date, sync:
 
@@ -27,8 +27,8 @@ found in this file (using v0.1.2 as an example):
    Or edit the `.version` file manually:
 
    ```diff
-   - 0.1.1
-   + 0.1.2
+   - 1.2.2
+   + 1.2.3
    ```
 
 1. Update the changelog:
@@ -56,7 +56,7 @@ found in this file (using v0.1.2 as an example):
 
    - _No changes yet._
 
-   ## [0.1.2] - YYYY-MM-DD
+   ## [1.2.3] - YYYY-MM-DD
 
    ```
 
@@ -95,21 +95,21 @@ found in this file (using v0.1.2 as an example):
    > complete the release process. If not, or only partially, continue following
    > the remaining steps.
 
-1. Update the `v0` branch to point to the same commit as the new tag:
+1. Update the `v1` branch to point to the same commit as the new tag:
 
    ```shell
-   git checkout v0
+   git checkout v1
    git merge main
    ```
 
-1. Push the `v0` branch:
+1. Push the `v1` branch:
 
    ```shell
-   git push origin v0
+   git push origin v1
    ```
 
 1. Create a [GitHub Release] for the [git tag] of the new release. The release
-   title should be "Release {_version_}" (e.g. "Release v0.1.2"). The release
+   title should be "Release {_version_}" (e.g. "Release v1.2.3"). The release
    text should be identical.
 
    Ensure the version is published to the [GitHub Marketplace] as well.

--- a/commit/README.md
+++ b/commit/README.md
@@ -8,7 +8,7 @@ file through a commit.
 ## Usage
 
 ```yml
-- uses: ericcornelissen/tool-versions-update-action/commit@v0
+- uses: ericcornelissen/tool-versions-update-action/commit@v1
   with:
     # The branch to commit to.
     #
@@ -131,7 +131,7 @@ jobs:
       contents: write
     steps:
       - name: Update tooling
-        uses: ericcornelissen/tool-versions-update-action/commit@v0
+        uses: ericcornelissen/tool-versions-update-action/commit@v1
         with:
           max: 2
 ```

--- a/pr/README.md
+++ b/pr/README.md
@@ -8,7 +8,7 @@ file through a Pull Request.
 ## Usage
 
 ```yml
-- uses: ericcornelissen/tool-versions-update-action/pr@v0
+- uses: ericcornelissen/tool-versions-update-action/pr@v1
   with:
     # A comma or newline-separated list of assignees for Pull Requests (by their
     # GitHub username).
@@ -196,7 +196,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Update tooling
-        uses: ericcornelissen/tool-versions-update-action/pr@v0
+        uses: ericcornelissen/tool-versions-update-action/pr@v1
 ```
 
 For more examples see the [recipes].
@@ -268,7 +268,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Update tooling
-        uses: ericcornelissen/tool-versions-update-action/pr@v0
+        uses: ericcornelissen/tool-versions-update-action/pr@v1
         with:
           branch: bot/tool_versions/${{ matrix.tool }}
           only: ${{ matrix.tool }}
@@ -302,7 +302,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Update tooling
-        uses: ericcornelissen/tool-versions-update-action/pr@v0
+        uses: ericcornelissen/tool-versions-update-action/pr@v1
         with:
           max: 1
 ```


### PR DESCRIPTION
Relates to #189

## Summary

Update the (contributor and user-facing) documentation to refer to version 1 instead of (the now end-of-life) version 0.