### PR TITLE
Add output templating support to input `branch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,12 @@ Versioning].
 
 ### `tool-versions-update-action/commit`
 
-- _No changes yet._
+- Add support for templating to the input `branch`.
 
 ### `tool-versions-update-action/pr`
 
 - Add input `rebase-strategy` to configure when Pull Requests are rebased.
+- Add support for templating to the input `branch`.
 
 ## [1.0.0] - 2024-01-15
 

--- a/commit/README.md
+++ b/commit/README.md
@@ -12,6 +12,9 @@ file through a commit.
   with:
     # The branch to commit to.
     #
+    # This input supports templating, see the "Templating" section for more
+    # information.
+    #
     # Default: *current or default branch*
     branch: develop
 
@@ -102,6 +105,7 @@ This template string uses the '3' output
 
 The following inputs support templating:
 
+- `branch`
 - `commit-message`
 
 The following outputs are available for templating:

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -121,6 +121,17 @@ runs:
         UPDATED_NEW_VERSIONS: ${{ steps.update.outputs.updated-new-versions }}
         UPDATED_OLD_VERSIONS: ${{ steps.update.outputs.updated-old-versions }}
         UPDATED_TOOLS: ${{ steps.update.outputs.updated-tools }}
+    - name: Branch name
+      id: branch
+      shell: bash
+      run: $GITHUB_ACTION_PATH/../bin/templating.sh
+      env:
+        TEXT: ${{ inputs.branch }}
+        UPDATED_COUNT: ${{ steps.update.outputs.updated-count }}
+        UPDATED_NEW_VERSIONS: ${{ steps.update.outputs.updated-new-versions }}
+        UPDATED_OLD_VERSIONS: ${{ steps.update.outputs.updated-old-versions }}
+        UPDATED_TOOLS: ${{ steps.update.outputs.updated-tools }}
+
     - name: Commit options
       id: commit-options
       shell: bash
@@ -139,7 +150,7 @@ runs:
         skip_dirty_check: false
 
         # Branch
-        branch: ${{ inputs.branch }}
+        branch: ${{ steps.branch.outputs.value }}
 
         # Commit
         commit_message: ${{ steps.commit-message.outputs.value }}

--- a/pr/README.md
+++ b/pr/README.md
@@ -18,6 +18,9 @@ file through a Pull Request.
 
     # The branch name to use for Pull Requests.
     #
+    # This input supports templating, see the "Templating" section for more
+    # information.
+    #
     # Default: "tool-versions-updates"
     branch: update-tooling
 
@@ -164,6 +167,7 @@ This template string uses the '3' output
 
 The following inputs support templating:
 
+- `branch`
 - `commit-message`
 - `pr-body`
 - `pr-title`
@@ -270,7 +274,7 @@ jobs:
       - name: Update tooling
         uses: ericcornelissen/tool-versions-update-action/pr@v1
         with:
-          branch: bot/tool_versions/${{ matrix.tool }}
+          branch: bot/tool_versions/{{updated-tools}}-{{updated-new-versions}}
           only: ${{ matrix.tool }}
 ```
 

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -237,6 +237,16 @@ runs:
         UPDATED_NEW_VERSIONS: ${{ steps.update.outputs.updated-new-versions }}
         UPDATED_OLD_VERSIONS: ${{ steps.update.outputs.updated-old-versions }}
         UPDATED_TOOLS: ${{ steps.update.outputs.updated-tools }}
+    - name: Branch name
+      id: branch
+      shell: bash
+      run: $GITHUB_ACTION_PATH/../bin/templating.sh
+      env:
+        TEXT: ${{ inputs.branch }}
+        UPDATED_COUNT: ${{ steps.update.outputs.updated-count }}
+        UPDATED_NEW_VERSIONS: ${{ steps.update.outputs.updated-new-versions }}
+        UPDATED_OLD_VERSIONS: ${{ steps.update.outputs.updated-old-versions }}
+        UPDATED_TOOLS: ${{ steps.update.outputs.updated-tools }}
 
     - name: Check if a Pull Request exists and has been modified
       if: ${{ inputs.rebase-strategy == 'untouched' }}
@@ -252,7 +262,7 @@ runs:
         fi
       env:
         BASE: ${{ inputs.pr-base }}
-        BRANCH: ${{ inputs.branch }}
+        BRANCH: ${{ steps.branch.outputs.value }}
     - name: Check if a Pull Request already exists
       if: ${{ inputs.rebase-strategy == 'never' }}
       id: pr-exists
@@ -263,7 +273,7 @@ runs:
           echo "value=true" >>"${GITHUB_OUTPUT}"
         fi
       env:
-        BRANCH: ${{ inputs.branch }}
+        BRANCH: ${{ steps.branch.outputs.value }}
 
     - name: Create Pull Request
       if:
@@ -285,7 +295,7 @@ runs:
         milestone: ${{ inputs.milestone }}
 
         # Branch
-        branch: ${{ inputs.branch }}
+        branch: ${{ steps.branch.outputs.value }}
 
         # Commit
         commit-message: ${{ steps.commit-message.outputs.value }}


### PR DESCRIPTION
Closes #188
Relates to #180

## Summary

Enable templating of output values into the `branch` input. Include an example of how to use this in the recipes for the `/pr` Action variant.