### PR TITLE
Upgrade development environment to Alpine 3.19.1

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -3,7 +3,7 @@
 # Check out Docker at: https://www.docker.com/
 # Check out Podman at: https://podman.io/
 
-FROM docker.io/alpine:3.18.4
+FROM docker.io/alpine:3.19.1
 
 RUN apk add --no-cache \
 	bash curl git jq make python3 py3-pip


### PR DESCRIPTION
Relates to #105, #136

## Summary

Upgrade the development environment's base image from Alpine 3.18.4 to 3.19.1 - the latest available version.