### PR TITLE
Buffer the tool-versions file when updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,18 @@ Versioning].
 
 ### `tool-versions-update-action`
 
-- _No changes yet._
+- Fix failures due to tool updates that change the length of a version string.
 
 ### `tool-versions-update-action/commit`
 
 - Bump `actions/checkout` from v4.1.3 to v4.1.4.
+- Fix failures due to tool updates that change the length of a version string.
 
 ### `tool-versions-update-action/pr`
 
 - Bump `actions/checkout` from v4.1.3 to v4.1.4.
 - Bump `peter-evans/create-pull-request` from v6.0.4 to v6.0.5.
+- Fix failures due to tool updates that change the length of a version string.
 
 ## [1.1.2] - 2024-04-23
 

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -67,6 +67,8 @@ fi
 group_start "Updating tools"
 debug "starting with update capacity: ${remaining_capacity}"
 
+tool_versions="$(cat '.tool-versions')"
+
 while read -r line; do
 	case "${line}" in
 	"")
@@ -160,6 +162,6 @@ while read -r line; do
 		fi
 		;;
 	esac
-done <".tool-versions"
+done <<<"${tool_versions}"
 
 group_end


### PR DESCRIPTION
Closes #258, [Tooling / Update #302](https://github.com/ericcornelissen/tool-versions-update-action/actions/runs/9012273848)

## Summary

Update the `update.sh` script to buffer the contents of the .tool-versions file. This is so as to avoid incorrect behavior due to changes made to the file during the loop. For example, an update might result in a version string that is shorter or longer than the original. This can result in buggy behavior due to a changed offset when reading the next line.

This was detected when an update attempting to upgrade `actionlint` from version 1.6.27 to version 1.7.0 resulted in an error because the next line would be started to be read at an offset of 1 (so "adolint 2.12.0" instead of "hadolint 2.12.0").