### PR TITLE
Stop using Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,10 +38,3 @@ jobs:
         run: sudo apt-get install kcov
       - name: Run unit tests
         run: make coverage
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # v4.3.0
-        if: ${{ matrix.runs-on == 'ubuntu-22.04' }}
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          file: ./_coverage/tool-versions-update-action [specfiles]/cobertura.xml


### PR DESCRIPTION
Relates to #137

## Summary

Stop using Codecov in an effort to minimize dependencies and secrets used in this project. The integration is largely unused (at least by me).