### PR TITLE
Set up basic GitHub Actions SAST with `ades`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,6 +30,14 @@ jobs:
         run: make lint-container
       - name: Build
         run: make dev-img
+  sast:
+    name: SAST
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - name: Static application security testing
+        run: make sast
   shell:
     name: Shell scripts
     runs-on: ubuntu-22.04

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,16 @@ lint-sh: $(ASDF) ## Lint shell scripts
 lint-yml: $(ASDF) ## Lint YAML files
 	@yamllint -c .yamllint.yml .
 
+.PHONY: sast
+sast: ## Perform static application security testing
+	@$(CONTAINER_ENGINE) run \
+		--rm \
+		--volume $(shell pwd):/src \
+		docker.io/ericornelissen/ades:v24.06 \
+		./commit/action.yml \
+		./pr/action.yml \
+		./action.yml
+
 .PHONY: test test-e2e
 test: $(ASDF) | $(TMP_DIR) ## Run tests
 	@shellspec


### PR DESCRIPTION
Relates to #14

## Summary

Integrate a (created-by-me) SAST for GitHub actions, called [ades](https://github.com/ericcornelissen/ades), into the development of this project with a Make command and CI/CD job. Running it with Docker as a managed package manager since it's not available through asdf, as a GitHub Action, nor as a system package.