### PR TITLE
Bump composite action dependency `peter-evans/create-pull-request` to v7.0.0

### DIFF
--- a/.github/workflows/transitive-actions.yml
+++ b/.github/workflows/transitive-actions.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           GH_ADMIN_TOKEN: ${{ github.token }}
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@4320041ed380b20e97d388d56a7fb4f9b8c20e79 # pin@v5
+        uses: peter-evans/create-pull-request@4320041ed380b20e97d388d56a7fb4f9b8c20e79 # v7.0.0
         with:
           token: ${{ steps.automation-token.outputs.token }}
           title: Update composite action dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Versioning].
 ### `tool-versions-update-action/pr`
 
 - Bump `actions/checkout` from v4.1.5 to v4.1.7.
-- Bump `peter-evans/create-pull-request` from v6.0.5 to v6.1.0.
+- Bump `peter-evans/create-pull-request` from v6.0.5 to v7.0.0.
 
 ## [1.1.3] - 2024-05-09
 

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -278,7 +278,7 @@ runs:
     - name: Create Pull Request
       if: ${{ steps.update.outputs.updated-count != '0' && steps.pr-modified.outputs.value != 'true' && steps.pr-exists.outputs.value != 'true' }}
       id: create-pr
-      uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # pin@v6
+      uses: peter-evans/create-pull-request@4320041ed380b20e97d388d56a7fb4f9b8c20e79 # pin@v7
       with:
         token: ${{ inputs.token }}
 


### PR DESCRIPTION
Relates to #280, #297

## Summary

Update the version of `peter-evans/create-pull-request` used in the /pr variant to the latest available version.
