### PR TITLE
Replace `gitleaks` by `trufflehog`

### DIFF
--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -19,9 +19,6 @@ jobs:
         with:
           fetch-depth: 0
       - name: Scan for secrets
-        uses: gitleaks/gitleaks-action@cb7149a9b57195b609c63e8518d2c6056677d2d0 # v2.3.3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_ENABLE_COMMENTS: false
-          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
-          GITLEAKS_ENABLE_SUMMARY: false
+        uses: trufflesecurity/trufflehog@0328a19a9d3877c9f04d0dbee5717aabff5b575d # v3.82.6
+        with:
+          extra_args: --only-verified


### PR DESCRIPTION
Relates to #21

## Summary

Update the secret scanning workflow to replace `gitleaks` by `trufflehog`. This is mostly because the `gitleaks` action is facing some technical challenges that aren't being addressed (build problems leading to use of deprecated functionality).

The primary drawback I see for using `trufflehog` over `gitleaks` is that the action isn't really pinnable (it's a composable action that runs a Docker image). The VERSION input could be used to pin the container, but that wouldn't be supported by automation to auto-update. For this use case and this purpose I'd prefer staying up-to-date with latest automatically (and I'd just like to try `trufflehog` for an extended period of time).