### PR TITLE
Bump `pin-github-action` from ^1.5.0 to ^2.0.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ update-actions: ## Update (and pin) all actions used by these actions
 		\
 		"--update-notifier=false" \
 		"--yes" \
-		"pin-github-action@^1.5.0" \
+		"pin-github-action@^2.0.2" \
 		"commit/action.yml" "pr/action.yml" "action.yml"
 
 .PHONY: verify

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -276,7 +276,10 @@ runs:
         BRANCH: ${{ steps.branch.outputs.value }}
 
     - name: Create Pull Request
-      if: ${{ steps.update.outputs.updated-count != '0' && steps.pr-modified.outputs.value != 'true' && steps.pr-exists.outputs.value != 'true' }}
+      if:
+        ${{ steps.update.outputs.updated-count != '0' &&
+            steps.pr-modified.outputs.value != 'true' &&
+            steps.pr-exists.outputs.value != 'true' }}
       id: create-pr
       uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # pin@v7
       with:


### PR DESCRIPTION
Relates to #50, #187, #194

## Summary

Update the version of `pin-github-action` used to benefit from an update that fixed the reformatting of updated workflows. Accordingly, adjust formatting of the Action manifest files.