### PR TITLE
Set up CodeQL for scanning GitHub Actions

### DIFF
--- a/.github/codeql.yml
+++ b/.github/codeql.yml
@@ -1,0 +1,6 @@
+# Check out CodeQL at: https://codeql.github.com/
+
+name: tool-versions-update-action CodeQL config
+
+queries:
+  - uses: security-extended

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: CodeQL
+on:
+  pull_request:
+    paths:
+      - .github/workflows/*
+      - .github/codeql.yml
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: 0 2 * * *
+  workflow_dispatch: ~
+
+permissions: read-all
+
+jobs:
+  codeql:
+    name: actions
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write # To upload CodeQL results
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@d68b2d4edb4189fd2a5366ac14e72027bd4b37dd # v3.28.2
+        with:
+          config-file: ./.github/codeql.yml
+          languages: actions
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@d68b2d4edb4189fd2a5366ac14e72027bd4b37dd # v3.28.2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,9 +7,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: 0 2 * * *
-  workflow_dispatch: ~
 
 permissions: read-all
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
       - name: Upload Semgrep report to GitHub
-        uses: github/codeql-action/upload-sarif@662472033e021d55d94146f66f6058822b0b39fd # v3.27.0
+        uses: github/codeql-action/upload-sarif@d68b2d4edb4189fd2a5366ac14e72027bd4b37dd # v3.28.2
         if: ${{ failure() || success() }}
         with:
           sarif_file: semgrep.sarif

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@
 ## GitHub platform
 !/.github/
 /.github/**
+!/.github/codeql.yml
 !/.github/dependabot.yml
 !/.github/labeler.yml
 !/.github/workflows


### PR DESCRIPTION
Note: per the [code scanning docs](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql), only "GitHub Actions workflows" are supported. Hence, the workflow is not configured to trigger for changes to `action.yml` manifest files.