### PR TITLE
Drop `ubuntu-20.04` support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,6 @@ jobs:
       fail-fast: false
       matrix:
         runs-on:
-          - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
     steps:

--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ jobs:
 
 ### Runners
 
-This action is tested on the official [`ubuntu-20.04`], [`ubuntu-22.04`], and
-[`ubuntu-24.04`] runner images. It is recommended to use one of these images
-when using this action.
+This action is tested on the official [`ubuntu-22.04`] and [`ubuntu-24.04`]
+runner images. It is recommended to use one of these images when using this
+action.
 
 ### Security
 
@@ -124,6 +124,5 @@ snippets under the [MIT-0 license].
 [license]: ./LICENSE
 [mit license]: https://opensource.org/license/mit/
 [mit-0 license]: https://opensource.org/license/mit-0/
-[`ubuntu-20.04`]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md
 [`ubuntu-22.04`]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
 [`ubuntu-24.04`]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md

--- a/commit/README.md
+++ b/commit/README.md
@@ -142,9 +142,9 @@ jobs:
 
 ### Runners
 
-This action is tested on the official [`ubuntu-20.04`], [`ubuntu-22.04`], and
-[`ubuntu-24.04`] runner images. It is recommended to use one of these images
-when using this action.
+This action is tested on the official [`ubuntu-22.04`] and [`ubuntu-24.04`]
+runner images. It is recommended to use one of these images when using this
+action.
 
 ### Security
 
@@ -178,6 +178,5 @@ under the [MIT-0 license].
 [github action]: https://github.com/features/actions
 [github actions output docs]: https://help.github.com/en/actions/reference/contexts-and-expression-syntax-for-github-actions#steps-context
 [mit-0 license]: https://opensource.org/license/mit-0/
-[`ubuntu-20.04`]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md
 [`ubuntu-22.04`]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
 [`ubuntu-24.04`]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md

--- a/pr/README.md
+++ b/pr/README.md
@@ -207,9 +207,9 @@ For more examples see the [recipes].
 
 ### Runners
 
-This action is tested on the official [`ubuntu-20.04`], [`ubuntu-22.04`], and
-[`ubuntu-24.04`] runner images. It is recommended to use one of these images
-when using this action.
+This action is tested on the official [`ubuntu-22.04`] and [`ubuntu-24.04`]
+runner images. It is recommended to use one of these images when using this
+action.
 
 ### Security
 
@@ -321,6 +321,5 @@ under the [MIT-0 license].
 [github actions output docs]: https://help.github.com/en/actions/reference/contexts-and-expression-syntax-for-github-actions#steps-context
 [mit-0 license]: https://opensource.org/license/mit-0/
 [recipes]: #recipes
-[`ubuntu-20.04`]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md
 [`ubuntu-22.04`]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
 [`ubuntu-24.04`]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md


### PR DESCRIPTION
## Summary

This removes explicit support for the `ubuntu-20.04` given that GitHub is retiring it on April 1, 2025, see <https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/>.