### PR TITLE
Bump `asdf-vm/actions` from v3 to v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,12 @@ Versioning].
 ### `tool-versions-update-action/commit`
 
 - Bump `actions/checkout` from v4.3.0 to v5.0.0.
+- Bump `asdf-vm/actions` from v3.0.2 to v4.0.0.
 
 ### `tool-versions-update-action/pr`
 
 - Bump `actions/checkout` from v4.3.0 to v5.0.0.
+- Bump `asdf-vm/actions` from v3.0.2 to v4.0.0.
 
 ## [1.1.6] - 2025-08-23
 

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -90,7 +90,7 @@ runs:
 
     - name: Setup asdf
       if: ${{ inputs.plugins != '' }}
-      uses: asdf-vm/actions/setup@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # pin@v4
+      uses: asdf-vm/actions/setup@1902764435ca0dd2f3388eea723a4f92a4eb8302 # pin@v4
     - name: Configure asdf plugins
       if: ${{ inputs.plugins != '' }}
       shell: bash
@@ -99,7 +99,7 @@ runs:
         LIST: ${{ inputs.plugins }}
 
     - name: Install asdf
-      uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # pin@v4
+      uses: asdf-vm/actions/install@1902764435ca0dd2f3388eea723a4f92a4eb8302 # pin@v4
 
     - name: Look for updates
       id: update

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -144,7 +144,7 @@ runs:
 
     - name: Setup asdf
       if: ${{ inputs.plugins != '' }}
-      uses: asdf-vm/actions/setup@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # pin@v4
+      uses: asdf-vm/actions/setup@1902764435ca0dd2f3388eea723a4f92a4eb8302 # pin@v4
     - name: Configure asdf plugins
       if: ${{ inputs.plugins != '' }}
       shell: bash
@@ -153,7 +153,7 @@ runs:
         LIST: ${{ inputs.plugins }}
 
     - name: Install asdf
-      uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # pin@v4
+      uses: asdf-vm/actions/install@1902764435ca0dd2f3388eea723a4f92a4eb8302 # pin@v4
 
     - name: Look for updates
       id: update


### PR DESCRIPTION
Relates to https://github.com/ericcornelissen/tool-versions-update-action/issues/384#issuecomment-3217253391

## Summary

This bumps the use of `asdf-vm/actions` transitively (through [`/pr`](https://github.com/ericcornelissen/tool-versions-update-action/tree/fb229b718c41929b6ae4af3e6fda65cca3b894a8/pr) and [`/commit`](https://github.com/ericcornelissen/tool-versions-update-action/tree/fb229b718c41929b6ae4af3e6fda65cca3b894a8/commit)) from v3 to v4. This is a breaking change for this action following the breaking change it is for that action (see [`asdf-vm/actions` v4.0.0](https://github.com/asdf-vm/actions/releases/tag/v4.0.0) release notes for details).