### PR TITLE
Bump `stefanzweifel/git-auto-commit-action` from v5 to v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Versioning].
 ### `tool-versions-update-action/commit`
 
 - Bump `actions/checkout` from v4.2.2 to v4.3.0.
-- Bump `stefanzweifel/git-auto-commit-action` from v5.0.1 to v5.2.0.
+- Bump `stefanzweifel/git-auto-commit-action` from v5.0.1 to v6.0.1.
 
 ### `tool-versions-update-action/pr`
 

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -145,7 +145,7 @@ runs:
     - name: Create commit
       if: ${{ steps.update.outputs.updated-count != '0' }}
       id: create-commit
-      uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # pin@v5
+      uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # pin@v6
       with:
         skip_dirty_check: false
 


### PR DESCRIPTION
Relates to https://github.com/ericcornelissen/tool-versions-update-action/issues/384#issuecomment-3217253391

## Summary

This bumps the use of `stefanzweifel/git-auto-commit-action` transitively (through [`/commit`](https://github.com/ericcornelissen/tool-versions-update-action/tree/fb229b718c41929b6ae4af3e6fda65cca3b894a8/commit)) from v5 to v6. Breaking changes do not affect usage here.