### PR TITLE
Bump transitive `actions/checkout` from v6.0.3 to v7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,11 @@ Versioning].
 
 ### `tool-versions-update-action/commit`
 
-- Bump `actions/checkout` from v6.0.1 to v6.0.3.
+- Bump `actions/checkout` from v6.0.1 to v7.0.0.
 
 ### `tool-versions-update-action/pr`
 
-- Bump `actions/checkout` from v6.0.1 to v6.0.3.
+- Bump `actions/checkout` from v6.0.1 to v7.0.0.
 - Bump `peter-evans/create-pull-request` from v8.0.0 to v8.1.1.
 
 ## [2.2.1] - 2025-12-24

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -99,7 +99,7 @@ runs:
   using: composite
   steps:
     - name: Checkout repository
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # pin@v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v7
       with:
         token: ${{ inputs.token }}
         persist-credentials: true

--- a/pr/action.yml
+++ b/pr/action.yml
@@ -154,7 +154,7 @@ runs:
   using: composite
   steps:
     - name: Checkout repository
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # pin@v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v7
       with:
         fetch-depth: 0
         persist-credentials: true


### PR DESCRIPTION
Relates to [Transitive Actions job #1075](https://github.com/ericcornelissen/tool-versions-update-action/actions/runs/27815963200) and #502